### PR TITLE
Add admin content management, news, breeding planner, and care guide

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -7,8 +7,13 @@ require_once __DIR__ . '/settings.php';
 require_once __DIR__ . '/animals.php';
 require_once __DIR__ . '/adoption.php';
 require_once __DIR__ . '/users.php';
+require_once __DIR__ . '/pages.php';
+require_once __DIR__ . '/news.php';
+require_once __DIR__ . '/breeding.php';
+require_once __DIR__ . '/careguide.php';
 
 $pdo = get_database_connection();
 initialize_database($pdo);
 ensure_default_admin($pdo);
 ensure_default_settings($pdo);
+ensure_default_care_articles($pdo);

--- a/app/breeding.php
+++ b/app/breeding.php
@@ -1,0 +1,82 @@
+<?php
+function create_breeding_plan(PDO $pdo, array $data): int
+{
+    $stmt = $pdo->prepare('INSERT INTO breeding_plans(title, season, notes, expected_genetics, incubation_notes) VALUES (:title, :season, :notes, :expected_genetics, :incubation_notes)');
+    $stmt->execute([
+        'title' => $data['title'],
+        'season' => $data['season'] ?? null,
+        'notes' => $data['notes'] ?? null,
+        'expected_genetics' => $data['expected_genetics'] ?? null,
+        'incubation_notes' => $data['incubation_notes'] ?? null,
+    ]);
+    return (int)$pdo->lastInsertId();
+}
+
+function update_breeding_plan(PDO $pdo, int $id, array $data): void
+{
+    $stmt = $pdo->prepare('UPDATE breeding_plans SET title = :title, season = :season, notes = :notes, expected_genetics = :expected_genetics, incubation_notes = :incubation_notes WHERE id = :id');
+    $stmt->execute([
+        'title' => $data['title'],
+        'season' => $data['season'] ?? null,
+        'notes' => $data['notes'] ?? null,
+        'expected_genetics' => $data['expected_genetics'] ?? null,
+        'incubation_notes' => $data['incubation_notes'] ?? null,
+        'id' => $id,
+    ]);
+}
+
+function delete_breeding_plan(PDO $pdo, int $id): void
+{
+    $stmt = $pdo->prepare('DELETE FROM breeding_plans WHERE id = :id');
+    $stmt->execute(['id' => $id]);
+}
+
+function get_breeding_plan(PDO $pdo, int $id): ?array
+{
+    $stmt = $pdo->prepare('SELECT * FROM breeding_plans WHERE id = :id');
+    $stmt->execute(['id' => $id]);
+    $plan = $stmt->fetch();
+    if (!$plan) {
+        return null;
+    }
+    $plan['parents'] = get_breeding_parents($pdo, $id);
+    return $plan;
+}
+
+function get_breeding_plans(PDO $pdo): array
+{
+    $plans = $pdo->query('SELECT * FROM breeding_plans ORDER BY created_at DESC')->fetchAll();
+    foreach ($plans as &$plan) {
+        $plan['parents'] = get_breeding_parents($pdo, (int)$plan['id']);
+    }
+    return $plans;
+}
+
+function add_breeding_parent(PDO $pdo, array $data): void
+{
+    $stmt = $pdo->prepare('INSERT INTO breeding_plan_parents(plan_id, parent_type, animal_id, name, sex, species, genetics, notes) VALUES (:plan_id, :parent_type, :animal_id, :name, :sex, :species, :genetics, :notes)');
+    $stmt->execute([
+        'plan_id' => $data['plan_id'],
+        'parent_type' => $data['parent_type'],
+        'animal_id' => $data['parent_type'] === 'animal' ? ($data['animal_id'] ?: null) : null,
+        'name' => $data['name'] ?? null,
+        'sex' => $data['sex'] ?? null,
+        'species' => $data['species'] ?? null,
+        'genetics' => $data['genetics'] ?? null,
+        'notes' => $data['notes'] ?? null,
+    ]);
+}
+
+function delete_breeding_parent(PDO $pdo, int $id): void
+{
+    $stmt = $pdo->prepare('DELETE FROM breeding_plan_parents WHERE id = :id');
+    $stmt->execute(['id' => $id]);
+}
+
+function get_breeding_parents(PDO $pdo, int $planId): array
+{
+    $stmt = $pdo->prepare('SELECT breeding_plan_parents.*, animals.name AS animal_name, animals.species AS animal_species, animals.genetics AS animal_genetics FROM breeding_plan_parents LEFT JOIN animals ON animals.id = breeding_plan_parents.animal_id WHERE plan_id = :plan ORDER BY breeding_plan_parents.id ASC');
+    $stmt->execute(['plan' => $planId]);
+    return $stmt->fetchAll();
+}
+

--- a/app/careguide.php
+++ b/app/careguide.php
@@ -1,0 +1,161 @@
+<?php
+function create_care_article(PDO $pdo, array $data): int
+{
+    $slug = $data['slug'] ?: slugify($data['title']);
+    $slug = ensure_unique_slug($pdo, 'care_articles', $slug);
+    $stmt = $pdo->prepare('INSERT INTO care_articles(title, slug, summary, content, is_published) VALUES (:title, :slug, :summary, :content, :is_published)');
+    $stmt->execute([
+        'title' => $data['title'],
+        'slug' => $slug,
+        'summary' => $data['summary'] ?? null,
+        'content' => $data['content'],
+        'is_published' => !empty($data['is_published']) ? 1 : 0,
+    ]);
+    return (int)$pdo->lastInsertId();
+}
+
+function update_care_article(PDO $pdo, int $id, array $data): void
+{
+    $slug = $data['slug'] ?: slugify($data['title']);
+    $slug = ensure_unique_slug($pdo, 'care_articles', $slug, $id);
+    $stmt = $pdo->prepare('UPDATE care_articles SET title = :title, slug = :slug, summary = :summary, content = :content, is_published = :is_published, updated_at = CURRENT_TIMESTAMP WHERE id = :id');
+    $stmt->execute([
+        'title' => $data['title'],
+        'slug' => $slug,
+        'summary' => $data['summary'] ?? null,
+        'content' => $data['content'],
+        'is_published' => !empty($data['is_published']) ? 1 : 0,
+        'id' => $id,
+    ]);
+}
+
+function delete_care_article(PDO $pdo, int $id): void
+{
+    $stmt = $pdo->prepare('DELETE FROM care_articles WHERE id = :id');
+    $stmt->execute(['id' => $id]);
+}
+
+function get_care_articles(PDO $pdo): array
+{
+    return $pdo->query('SELECT * FROM care_articles ORDER BY title ASC')->fetchAll();
+}
+
+function get_published_care_articles(PDO $pdo): array
+{
+    return $pdo->query('SELECT * FROM care_articles WHERE is_published = 1 ORDER BY title ASC')->fetchAll();
+}
+
+function get_care_article(PDO $pdo, int $id): ?array
+{
+    $stmt = $pdo->prepare('SELECT * FROM care_articles WHERE id = :id');
+    $stmt->execute(['id' => $id]);
+    $article = $stmt->fetch();
+    return $article ?: null;
+}
+
+function get_care_article_by_slug(PDO $pdo, string $slug): ?array
+{
+    $stmt = $pdo->prepare('SELECT * FROM care_articles WHERE slug = :slug');
+    $stmt->execute(['slug' => $slug]);
+    $article = $stmt->fetch();
+    return $article ?: null;
+}
+
+function ensure_default_care_articles(PDO $pdo): void
+{
+    $stmt = $pdo->prepare('SELECT COUNT(*) FROM care_articles WHERE slug = :slug');
+    $stmt->execute(['slug' => 'pogona-vitticeps']);
+    if ($stmt->fetchColumn() > 0) {
+        return;
+    }
+
+    $summary = 'Kompletter Praxisleitfaden für die artgerechte Haltung, Ernährung, Technik und Gesundheitsvorsorge von Bartagamen (Pogona vitticeps).';
+    $content = <<<HTML
+<h2>Steckbrief</h2>
+<p><strong>Wissenschaftlicher Name:</strong> <em>Pogona vitticeps</em><br>
+<strong>Umgangssprache:</strong> Bartagame, Inland-Bearded Dragon<br>
+<strong>Herkunft:</strong> Halbwüsten &amp; Trockenwälder im Osten Australiens<br>
+<strong>Lebenserwartung:</strong> 10–14 Jahre bei optimaler Haltung</p>
+
+<h2>Terrarium &amp; Technik</h2>
+<p>Für adulte Tiere wird ein Mindestmaß von <strong>150 × 80 × 80&nbsp;cm</strong> (L × B × H) empfohlen. Jungtiere profitieren von einer kleineren Aufzuchtbox (z.&nbsp;B. 100 × 60 × 60&nbsp;cm), damit sie Futter leichter finden.</p>
+<ul>
+    <li><strong>Substrat:</strong> Lehm-Sand-Gemisch (z.&nbsp;B. 60&nbsp;% Spielsand, 40&nbsp;% Lehm) mit unterschiedlichen Schichthöhen. Punktuell Steinflächen für Krallenabrieb.</li>
+    <li><strong>Struktur:</strong> Rückwände, Wurzelholz, erhöhte Sonnenplätze, Höhlen. Mindestens drei Temperaturzonen schaffen.</li>
+    <li><strong>Luftfeuchte:</strong> 30–40&nbsp;% tagsüber, nachts kurzzeitig auf 50&nbsp;% erhöhen (leichtes Sprühen in einer Ecke).</li>
+</ul>
+
+<h3>Beleuchtung &amp; Wärme</h3>
+<table>
+    <thead>
+        <tr><th>Zone</th><th>Temperatur</th><th>Technik</th></tr>
+    </thead>
+    <tbody>
+        <tr><td>Sonnenplatz</td><td>45–50&nbsp;°C</td><td>Halogen-Spot (70–100&nbsp;W) + UV-HQI (z.&nbsp;B. 70&nbsp;W)</td></tr>
+        <tr><td>Grundtemperatur</td><td>28–32&nbsp;°C</td><td>Bright Sun, T5-HO Röhre 6500&nbsp;K für Tageslicht</td></tr>
+        <tr><td>Kühle Zone</td><td>24–26&nbsp;°C</td><td>schattige Bereiche, Rückzugsmöglichkeiten</td></tr>
+        <tr><td>Nacht</td><td>18–22&nbsp;°C</td><td>keine Heizmatten, ggf. Raumheizung</td></tr>
+    </tbody>
+</table>
+<p><strong>UV-B Versorgung:</strong> Hochwertige Mischlicht-/HQI-Lampe (z.&nbsp;B. SolarRaptor/Arcadia) mit Reflektor. Brenndauer 10–12&nbsp;h. Röhren jährlich, HQI alle 12–18&nbsp;Monate tauschen.</p>
+
+<h2>Ernährung</h2>
+<p>Bartagamen sind omnivor mit wechselnden Bedürfnissen im Altersverlauf.</p>
+<ul>
+    <li><strong>Jungtiere (0–6 Monate):</strong> 70&nbsp;% Insekten, 30&nbsp;% Pflanzliches. Täglich mehrere kleine Futterportionen.</li>
+    <li><strong>Subadulte (6–12 Monate):</strong> Verhältnis 50&nbsp;/ 50. Insekten auf drei bis vier Fütterungen pro Woche begrenzen.</li>
+    <li><strong>Adulte:</strong> 20–30&nbsp;% Insekten, Rest Wildkräuter &amp; Gemüse.</li>
+</ul>
+<p><strong>Geeignete Insekten:</strong> Heimchen, Grillen, Schaben, Heuschrecken, Soldatenfliegenlarven. Immer gut füttern (<em>gut-loaden</em>) und mit Calcium ohne D3 stauben.</p>
+<p><strong>Pflanzliche Komponenten:</strong> Löwenzahn, Wegerich, Golliwoog, Endivie, Zucchini, Kaktusfeige (ohne Dornen). Obst höchstens 1× monatlich als Leckerbissen.</p>
+<p><strong>Supplemente:</strong> Reines Calcium bei jeder Insektenfütterung, 1–2× pro Woche ein Kombipräparat mit Vitamin&nbsp;D3 und Spurenelementen.</p>
+
+<h2>Wasser &amp; Hygiene</h2>
+<ul>
+    <li>Flache Wasserschale täglich frisch befüllen, steht vorzugsweise im kühleren Bereich.</li>
+    <li>Feuchte Häutungsbox mit Sphagnum-Moos während Häutungsphasen anbieten.</li>
+    <li>Spotreinigung des Substrates täglich, Komplettreinigung alle 6–8&nbsp;Wochen.</li>
+</ul>
+
+<h2>Gesundheitsvorsorge</h2>
+<p>Mindestens 1× jährlich eine Kotprobe auf Parasiten untersuchen lassen. Achtet auf folgende Warnsignale:</p>
+<ul>
+    <li>Appetitverlust oder rapide Gewichtsabnahme</li>
+    <li>Lethargie, häufiges Sitzen mit geschlossenen Augen</li>
+    <li>Schwellungen am Unterkiefer (Hinweis auf Metabolische Knochenerkrankung)</li>
+    <li>Atemgeräusche, Nasenausfluss</li>
+</ul>
+<p>Bei Verdacht sofort reptilienkundigen Tierarzt aufsuchen. Ein digitales Gewichtstagebuch hilft, Trends frühzeitig zu erkennen.</p>
+
+<h2>Sozialverhalten &amp; Handling</h2>
+<p>Bartagamen sind Einzelgänger. Dauerhafte Paar- oder Gruppenhaltung führt häufig zu Stress. Sichtkontakte zwischen Terrarien sind möglich, aber Rückzugsmöglichkeiten müssen gewährleistet sein.</p>
+<p><strong>Handling:</strong> Tiere nie am Schwanz hochheben, sondern mit beiden Händen von unten stützen. Handling kurz halten (5–10&nbsp;Minuten) und stets mit Wärmequelle in der Nähe.</p>
+
+<h2>Reproduktion &amp; Zuchtplanung</h2>
+<p>Die Fortpflanzung sollte erst nach vollständiger Ausreifung (♀ ab 18&nbsp;Monaten, ♂ ab 16&nbsp;Monaten) erfolgen. Vor der Paarung Winterruhe (8–10&nbsp;Wochen bei 16&nbsp;°C) einplanen.</p>
+<ol>
+    <li><strong>Paarung &amp; Eiablage:</strong> Eiablagebox (30 × 40 × 25&nbsp;cm) mit feuchtem, grabfähigem Substrat bereitstellen.</li>
+    <li><strong>Inkubation:</strong> 29–31&nbsp;°C, 60–70&nbsp;% Luftfeuchte. Schlupf nach 55–65&nbsp;Tagen.</li>
+    <li><strong>Aufzucht:</strong> Jungtiere einzeln oder in Kleingruppen mit identischer Größe halten, tägliche Gewichtskontrolle.</li>
+</ol>
+
+<h2>Checkliste für den Alltag</h2>
+<ul>
+    <li>Tägliche Funktionskontrolle der Technik (Temperatur, UV-Licht)</li>
+    <li>Frisches Wasser &amp; Futter anreichen, Reste entfernen</li>
+    <li>Wöchentlich Gewicht und Allgemeinzustand dokumentieren</li>
+    <li>Halbjährlich Terrarium gründlich reinigen und Einrichtung prüfen</li>
+</ul>
+
+<p>Mit konsequenter Technikpflege, abwechslungsreicher Ernährung und klar strukturierten Terrarien lässt sich die Lebensqualität von <em>Pogona vitticeps</em> nachhaltig sichern.</p>
+HTML;
+
+    create_care_article($pdo, [
+        'title' => 'Pogona vitticeps – umfassender Pflegeleitfaden',
+        'slug' => 'pogona-vitticeps',
+        'summary' => $summary,
+        'content' => $content,
+        'is_published' => 1,
+    ]);
+}
+

--- a/app/database.php
+++ b/app/database.php
@@ -14,6 +14,7 @@ function get_database_connection(): PDO
     $pdo = new PDO('sqlite:' . DATA_PATH);
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
     $pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+    $pdo->exec('PRAGMA foreign_keys = ON');
     return $pdo;
 }
 
@@ -76,5 +77,63 @@ function initialize_database(PDO $pdo): void
         message TEXT NOT NULL,
         created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
         FOREIGN KEY(listing_id) REFERENCES adoption_listings(id)
+    )');
+
+    $pdo->exec('CREATE TABLE IF NOT EXISTS pages (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        title TEXT NOT NULL,
+        slug TEXT NOT NULL UNIQUE,
+        content TEXT NOT NULL,
+        is_published INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )');
+
+    $pdo->exec('CREATE TABLE IF NOT EXISTS news_posts (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        title TEXT NOT NULL,
+        slug TEXT NOT NULL UNIQUE,
+        excerpt TEXT,
+        content TEXT NOT NULL,
+        is_published INTEGER NOT NULL DEFAULT 0,
+        published_at TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )');
+
+    $pdo->exec('CREATE TABLE IF NOT EXISTS breeding_plans (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        title TEXT NOT NULL,
+        season TEXT,
+        notes TEXT,
+        expected_genetics TEXT,
+        incubation_notes TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )');
+
+    $pdo->exec('CREATE TABLE IF NOT EXISTS breeding_plan_parents (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        plan_id INTEGER NOT NULL,
+        parent_type TEXT NOT NULL,
+        animal_id INTEGER,
+        name TEXT,
+        sex TEXT,
+        species TEXT,
+        genetics TEXT,
+        notes TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY(plan_id) REFERENCES breeding_plans(id) ON DELETE CASCADE,
+        FOREIGN KEY(animal_id) REFERENCES animals(id)
+    )');
+
+    $pdo->exec('CREATE TABLE IF NOT EXISTS care_articles (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        title TEXT NOT NULL,
+        slug TEXT NOT NULL UNIQUE,
+        summary TEXT,
+        content TEXT NOT NULL,
+        is_published INTEGER NOT NULL DEFAULT 1,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
     )');
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -5,6 +5,16 @@ function view(string $template, array $data = []): void
         $data['currentRoute'] = $GLOBALS['currentRoute'];
     }
 
+    global $pdo;
+    if (isset($pdo)) {
+        if (!isset($data['navPages']) && function_exists('get_published_pages')) {
+            $data['navPages'] = get_published_pages($pdo);
+        }
+        if (!isset($data['navCareArticles']) && function_exists('get_published_care_articles')) {
+            $data['navCareArticles'] = get_published_care_articles($pdo);
+        }
+    }
+
     extract($data);
     include __DIR__ . '/../public/views/' . $template . '.php';
 }
@@ -96,4 +106,51 @@ function set_setting(PDO $pdo, string $key, string $value): void
 {
     $stmt = $pdo->prepare('REPLACE INTO settings(key, value) VALUES (:key, :value)');
     $stmt->execute(['key' => $key, 'value' => $value]);
+}
+
+function slugify(string $value): string
+{
+    $transliterated = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $value);
+    if ($transliterated !== false) {
+        $value = $transliterated;
+    }
+    $value = strtolower(trim($value));
+    $value = preg_replace('/[^a-z0-9]+/i', '-', $value);
+    $value = trim($value, '-');
+    return $value ?: bin2hex(random_bytes(4));
+}
+
+function ensure_unique_slug(PDO $pdo, string $table, string $slug, ?int $ignoreId = null): string
+{
+    $base = $slug ?: bin2hex(random_bytes(4));
+    $candidate = $base;
+    $counter = 1;
+
+    while (true) {
+        $sql = "SELECT COUNT(*) FROM {$table} WHERE slug = :slug";
+        $params = ['slug' => $candidate];
+        if ($ignoreId !== null) {
+            $sql .= ' AND id != :id';
+            $params['id'] = $ignoreId;
+        }
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute($params);
+        if ($stmt->fetchColumn() == 0) {
+            return $candidate;
+        }
+        $candidate = $base . '-' . (++$counter);
+    }
+}
+
+function render_rich_text(?string $value): string
+{
+    if ($value === null || $value === '') {
+        return '';
+    }
+
+    if (strpos($value, '<') === false) {
+        return nl2br(htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'));
+    }
+
+    return $value;
 }

--- a/app/news.php
+++ b/app/news.php
@@ -1,0 +1,75 @@
+<?php
+function create_news(PDO $pdo, array $data): int
+{
+    $slug = $data['slug'] ?: slugify($data['title']);
+    $slug = ensure_unique_slug($pdo, 'news_posts', $slug);
+    $publishedAt = !empty($data['is_published']) ? ($data['published_at'] ?: date('c')) : null;
+    $stmt = $pdo->prepare('INSERT INTO news_posts(title, slug, excerpt, content, is_published, published_at) VALUES (:title, :slug, :excerpt, :content, :is_published, :published_at)');
+    $stmt->execute([
+        'title' => $data['title'],
+        'slug' => $slug,
+        'excerpt' => $data['excerpt'] ?? null,
+        'content' => $data['content'],
+        'is_published' => !empty($data['is_published']) ? 1 : 0,
+        'published_at' => $publishedAt,
+    ]);
+    return (int)$pdo->lastInsertId();
+}
+
+function update_news(PDO $pdo, int $id, array $data): void
+{
+    $slug = $data['slug'] ?: slugify($data['title']);
+    $slug = ensure_unique_slug($pdo, 'news_posts', $slug, $id);
+    $publishedAt = !empty($data['is_published']) ? ($data['published_at'] ?: date('c')) : null;
+    $stmt = $pdo->prepare('UPDATE news_posts SET title = :title, slug = :slug, excerpt = :excerpt, content = :content, is_published = :is_published, published_at = :published_at, updated_at = CURRENT_TIMESTAMP WHERE id = :id');
+    $stmt->execute([
+        'title' => $data['title'],
+        'slug' => $slug,
+        'excerpt' => $data['excerpt'] ?? null,
+        'content' => $data['content'],
+        'is_published' => !empty($data['is_published']) ? 1 : 0,
+        'published_at' => $publishedAt,
+        'id' => $id,
+    ]);
+}
+
+function delete_news(PDO $pdo, int $id): void
+{
+    $stmt = $pdo->prepare('DELETE FROM news_posts WHERE id = :id');
+    $stmt->execute(['id' => $id]);
+}
+
+function get_news(PDO $pdo): array
+{
+    return $pdo->query('SELECT * FROM news_posts ORDER BY COALESCE(published_at, created_at) DESC')->fetchAll();
+}
+
+function get_news_post(PDO $pdo, int $id): ?array
+{
+    $stmt = $pdo->prepare('SELECT * FROM news_posts WHERE id = :id');
+    $stmt->execute(['id' => $id]);
+    $post = $stmt->fetch();
+    return $post ?: null;
+}
+
+function get_news_by_slug(PDO $pdo, string $slug): ?array
+{
+    $stmt = $pdo->prepare('SELECT * FROM news_posts WHERE slug = :slug');
+    $stmt->execute(['slug' => $slug]);
+    $post = $stmt->fetch();
+    return $post ?: null;
+}
+
+function get_published_news(PDO $pdo): array
+{
+    return $pdo->query('SELECT * FROM news_posts WHERE is_published = 1 ORDER BY COALESCE(published_at, created_at) DESC')->fetchAll();
+}
+
+function get_latest_published_news(PDO $pdo, int $limit = 3): array
+{
+    $stmt = $pdo->prepare('SELECT * FROM news_posts WHERE is_published = 1 ORDER BY COALESCE(published_at, created_at) DESC LIMIT :limit');
+    $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+    $stmt->execute();
+    return $stmt->fetchAll();
+}
+

--- a/app/pages.php
+++ b/app/pages.php
@@ -1,0 +1,61 @@
+<?php
+function create_page(PDO $pdo, array $data): int
+{
+    $slug = $data['slug'] ?: slugify($data['title']);
+    $slug = ensure_unique_slug($pdo, 'pages', $slug);
+    $stmt = $pdo->prepare('INSERT INTO pages(title, slug, content, is_published) VALUES (:title, :slug, :content, :is_published)');
+    $stmt->execute([
+        'title' => $data['title'],
+        'slug' => $slug,
+        'content' => $data['content'],
+        'is_published' => !empty($data['is_published']) ? 1 : 0,
+    ]);
+    return (int)$pdo->lastInsertId();
+}
+
+function update_page(PDO $pdo, int $id, array $data): void
+{
+    $slug = $data['slug'] ?: slugify($data['title']);
+    $slug = ensure_unique_slug($pdo, 'pages', $slug, $id);
+    $stmt = $pdo->prepare('UPDATE pages SET title = :title, slug = :slug, content = :content, is_published = :is_published, updated_at = CURRENT_TIMESTAMP WHERE id = :id');
+    $stmt->execute([
+        'title' => $data['title'],
+        'slug' => $slug,
+        'content' => $data['content'],
+        'is_published' => !empty($data['is_published']) ? 1 : 0,
+        'id' => $id,
+    ]);
+}
+
+function delete_page(PDO $pdo, int $id): void
+{
+    $stmt = $pdo->prepare('DELETE FROM pages WHERE id = :id');
+    $stmt->execute(['id' => $id]);
+}
+
+function get_page(PDO $pdo, int $id): ?array
+{
+    $stmt = $pdo->prepare('SELECT * FROM pages WHERE id = :id');
+    $stmt->execute(['id' => $id]);
+    $page = $stmt->fetch();
+    return $page ?: null;
+}
+
+function get_page_by_slug(PDO $pdo, string $slug): ?array
+{
+    $stmt = $pdo->prepare('SELECT * FROM pages WHERE slug = :slug');
+    $stmt->execute(['slug' => $slug]);
+    $page = $stmt->fetch();
+    return $page ?: null;
+}
+
+function get_pages(PDO $pdo): array
+{
+    return $pdo->query('SELECT * FROM pages ORDER BY created_at DESC')->fetchAll();
+}
+
+function get_published_pages(PDO $pdo): array
+{
+    return $pdo->query('SELECT * FROM pages WHERE is_published = 1 ORDER BY title ASC')->fetchAll();
+}
+

--- a/public/assets/admin.js
+++ b/public/assets/admin.js
@@ -1,0 +1,76 @@
+(function () {
+    if (typeof document === 'undefined') {
+        return;
+    }
+
+    function createButton(label, title, onClick) {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'rich-text-btn';
+        button.innerHTML = label;
+        button.title = title;
+        button.addEventListener('click', (event) => {
+            event.preventDefault();
+            onClick();
+        });
+        return button;
+    }
+
+    function wrapTextarea(textarea) {
+        if (textarea.dataset.richTextified) {
+            return;
+        }
+        textarea.dataset.richTextified = 'true';
+
+        const wrapper = document.createElement('div');
+        wrapper.className = 'rich-text-wrapper';
+
+        const toolbar = document.createElement('div');
+        toolbar.className = 'rich-text-toolbar';
+
+        const editor = document.createElement('div');
+        editor.className = 'rich-text-editor';
+        editor.contentEditable = 'true';
+        editor.innerHTML = textarea.value;
+
+        const commands = [
+            { label: '<strong>B</strong>', title: 'Fett', action: () => document.execCommand('bold', false) },
+            { label: '<em>I</em>', title: 'Kursiv', action: () => document.execCommand('italic', false) },
+            { label: '<u>U</u>', title: 'Unterstrichen', action: () => document.execCommand('underline', false) },
+            { label: '&#8226;', title: 'Aufzählung', action: () => document.execCommand('insertUnorderedList', false) },
+            { label: '&#35;', title: 'Nummerierung', action: () => document.execCommand('insertOrderedList', false) },
+            { label: '&#128279;', title: 'Link einfügen', action: () => {
+                const url = window.prompt('Link-Adresse (inkl. https://)');
+                if (url) {
+                    document.execCommand('createLink', false, url);
+                }
+            } },
+            { label: '&#9003;', title: 'Formatierung löschen', action: () => document.execCommand('removeFormat', false) }
+        ];
+
+        commands.forEach((command) => toolbar.appendChild(createButton(command.label, command.title, command.action)));
+
+        textarea.style.display = 'none';
+        textarea.parentNode.insertBefore(wrapper, textarea);
+        wrapper.appendChild(toolbar);
+        wrapper.appendChild(editor);
+        wrapper.appendChild(textarea);
+
+        const sync = () => {
+            textarea.value = editor.innerHTML.trim();
+        };
+
+        editor.addEventListener('input', sync);
+        editor.addEventListener('blur', sync);
+
+        const form = textarea.closest('form');
+        if (form) {
+            form.addEventListener('submit', sync);
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        document.querySelectorAll('textarea.rich-text').forEach(wrapTextarea);
+    });
+})();
+

--- a/public/assets/style.css
+++ b/public/assets/style.css
@@ -218,6 +218,10 @@ button:hover,
   color: var(--text);
 }
 
+.btn-secondary:hover {
+  color: var(--text);
+}
+
 .alert {
   padding: 1rem 1.25rem;
   border-radius: 16px;
@@ -261,6 +265,131 @@ button:hover,
 .admin-nav a.active {
   background: rgba(34, 211, 238, 0.25);
   color: var(--accent);
+}
+
+.rich-text-wrapper {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.rich-text-toolbar {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.rich-text-btn {
+  background: rgba(148, 163, 184, 0.18);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  color: var(--text);
+  padding: 0.35rem 0.6rem;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.rich-text-btn:hover {
+  background: rgba(34, 211, 238, 0.2);
+  color: var(--accent);
+}
+
+.rich-text-editor {
+  min-height: 160px;
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.65);
+  line-height: 1.6;
+  color: var(--text);
+  overflow-y: auto;
+}
+
+.rich-text-editor:focus {
+  outline: 2px solid rgba(34, 211, 238, 0.35);
+}
+
+.rich-text-content {
+  display: grid;
+  gap: 0.75rem;
+  line-height: 1.7;
+  color: var(--text);
+}
+
+.rich-text-content p {
+  margin: 0;
+}
+
+.rich-text-content ul,
+.rich-text-content ol {
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.rich-text-content table {
+  width: 100%;
+  border-collapse: collapse;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.rich-text-content table th,
+.rich-text-content table td {
+  padding: 0.6rem 0.8rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.stack {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.plan-entry {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 18px;
+  padding: 1.5rem;
+  background: rgba(15, 23, 42, 0.55);
+  display: grid;
+  gap: 1rem;
+}
+
+.plan-entry__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.plan-entry__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.plan-entry__section {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.plan-parents {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.plan-parents li {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 14px;
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.45);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.plan-parent__title {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  align-items: center;
 }
 
 @media (max-width: 768px) {

--- a/public/index.php
+++ b/public/index.php
@@ -28,7 +28,9 @@ switch ($route) {
         $settings = get_all_settings($pdo);
         $animals = get_showcased_animals($pdo);
         $listings = get_public_listings($pdo);
-        view('home', compact('settings', 'animals', 'listings'));
+        $latestNews = get_latest_published_news($pdo, 3);
+        $careHighlights = array_slice(get_published_care_articles($pdo), 0, 3);
+        view('home', compact('settings', 'animals', 'listings', 'latestNews', 'careHighlights'));
         break;
 
     case 'animals':
@@ -42,6 +44,13 @@ switch ($route) {
         $settings = get_all_settings($pdo);
         $animals = get_user_animals($pdo, current_user()['id']);
         view('animals/my_animals', compact('settings', 'animals'));
+        break;
+
+    case 'breeding':
+        require_login();
+        $settings = get_all_settings($pdo);
+        $breedingPlans = get_breeding_plans($pdo);
+        view('breeding/index', compact('settings', 'breedingPlans'));
         break;
 
     case 'adoption':
@@ -71,13 +80,75 @@ switch ($route) {
         view('adoption/index', compact('settings', 'listings', 'flashSuccess', 'flashError'));
         break;
 
+    case 'page':
+        $slug = $_GET['slug'] ?? '';
+        $page = $slug ? get_page_by_slug($pdo, $slug) : null;
+        if (!$page || (!$page['is_published'] && (!current_user() || !is_authorized('can_manage_settings')))) {
+            http_response_code(404);
+            view('errors/404', ['settings' => get_all_settings($pdo)]);
+            break;
+        }
+        $settings = get_all_settings($pdo);
+        view('pages/show', [
+            'settings' => $settings,
+            'page' => $page,
+            'activePageSlug' => $page['slug'],
+        ]);
+        break;
+
+    case 'news':
+        $settings = get_all_settings($pdo);
+        $slug = $_GET['slug'] ?? null;
+        if ($slug) {
+            $post = get_news_by_slug($pdo, $slug);
+            if (!$post || (!$post['is_published'] && (!current_user() || !is_authorized('can_manage_settings')))) {
+                http_response_code(404);
+                view('errors/404', ['settings' => $settings]);
+                break;
+            }
+            view('news/show', [
+                'settings' => $settings,
+                'post' => $post,
+            ]);
+        } else {
+            $newsPosts = get_published_news($pdo);
+            view('news/index', compact('settings', 'newsPosts'));
+        }
+        break;
+
+    case 'care-guide':
+        $settings = get_all_settings($pdo);
+        $careArticles = get_published_care_articles($pdo);
+        view('care/index', compact('settings', 'careArticles'));
+        break;
+
+    case 'care-article':
+        $slug = $_GET['slug'] ?? '';
+        $article = $slug ? get_care_article_by_slug($pdo, $slug) : null;
+        if (!$article || (!$article['is_published'] && (!current_user() || !is_authorized('can_manage_settings')))) {
+            http_response_code(404);
+            view('errors/404', ['settings' => get_all_settings($pdo)]);
+            break;
+        }
+        $settings = get_all_settings($pdo);
+        view('care/show', [
+            'settings' => $settings,
+            'article' => $article,
+            'activeCareSlug' => $article['slug'],
+        ]);
+        break;
+
     case 'admin/dashboard':
         require_login();
         $settings = get_all_settings($pdo);
         $animals = get_animals($pdo);
         $listings = get_listings($pdo);
         $inquiries = get_inquiries($pdo);
-        view('admin/dashboard', compact('settings', 'animals', 'listings', 'inquiries'));
+        $pages = get_pages($pdo);
+        $newsPosts = get_news($pdo);
+        $breedingPlans = get_breeding_plans($pdo);
+        $careArticles = get_care_articles($pdo);
+        view('admin/dashboard', compact('settings', 'animals', 'listings', 'inquiries', 'pages', 'newsPosts', 'breedingPlans', 'careArticles'));
         break;
 
     case 'admin/settings':
@@ -101,6 +172,92 @@ switch ($route) {
         $settings = get_all_settings($pdo);
         $flashSuccess = flash('success');
         view('admin/settings', compact('settings', 'flashSuccess'));
+        break;
+
+    case 'admin/pages':
+        require_login();
+        if (!is_authorized('can_manage_settings')) {
+            flash('error', 'Keine Berechtigung.');
+            redirect('admin/dashboard');
+        }
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $data = [
+                'title' => trim($_POST['title'] ?? ''),
+                'slug' => trim($_POST['slug'] ?? ''),
+                'content' => $_POST['content'] ?? '',
+                'is_published' => isset($_POST['is_published']),
+            ];
+            if ($data['title'] && $data['content']) {
+                if (!empty($_POST['id'])) {
+                    update_page($pdo, (int)$_POST['id'], $data);
+                    flash('success', 'Seite aktualisiert.');
+                } else {
+                    create_page($pdo, $data);
+                    flash('success', 'Neue Seite angelegt.');
+                }
+                redirect('admin/pages');
+            } else {
+                flash('error', 'Titel und Inhalt werden benötigt.');
+            }
+        }
+        if (isset($_GET['delete'])) {
+            delete_page($pdo, (int)$_GET['delete']);
+            flash('success', 'Seite gelöscht.');
+            redirect('admin/pages');
+        }
+        $settings = get_all_settings($pdo);
+        $pages = get_pages($pdo);
+        $editPage = null;
+        if (isset($_GET['edit'])) {
+            $editPage = get_page($pdo, (int)$_GET['edit']);
+        }
+        $flashSuccess = flash('success');
+        $flashError = flash('error');
+        view('admin/pages', compact('settings', 'pages', 'editPage', 'flashSuccess', 'flashError'));
+        break;
+
+    case 'admin/news':
+        require_login();
+        if (!is_authorized('can_manage_settings')) {
+            flash('error', 'Keine Berechtigung.');
+            redirect('admin/dashboard');
+        }
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $data = [
+                'title' => trim($_POST['title'] ?? ''),
+                'slug' => trim($_POST['slug'] ?? ''),
+                'excerpt' => $_POST['excerpt'] ?? null,
+                'content' => $_POST['content'] ?? '',
+                'is_published' => isset($_POST['is_published']),
+                'published_at' => trim($_POST['published_at'] ?? ''),
+            ];
+            if ($data['title'] && $data['content']) {
+                if (!empty($_POST['id'])) {
+                    update_news($pdo, (int)$_POST['id'], $data);
+                    flash('success', 'Neuigkeit aktualisiert.');
+                } else {
+                    create_news($pdo, $data);
+                    flash('success', 'Neuigkeit veröffentlicht.');
+                }
+                redirect('admin/news');
+            } else {
+                flash('error', 'Titel und Inhalt werden benötigt.');
+            }
+        }
+        if (isset($_GET['delete'])) {
+            delete_news($pdo, (int)$_GET['delete']);
+            flash('success', 'Neuigkeit gelöscht.');
+            redirect('admin/news');
+        }
+        $settings = get_all_settings($pdo);
+        $newsPosts = get_news($pdo);
+        $editPost = null;
+        if (isset($_GET['edit'])) {
+            $editPost = get_news_post($pdo, (int)$_GET['edit']);
+        }
+        $flashSuccess = flash('success');
+        $flashError = flash('error');
+        view('admin/news', compact('settings', 'newsPosts', 'editPost', 'flashSuccess', 'flashError'));
         break;
 
     case 'admin/animals':
@@ -144,6 +301,84 @@ switch ($route) {
         view('admin/animals', compact('animals', 'users', 'editAnimal', 'flashSuccess', 'settings'));
         break;
 
+    case 'admin/breeding':
+        require_login();
+        if (!is_authorized('can_manage_animals')) {
+            flash('error', 'Keine Berechtigung.');
+            redirect('admin/dashboard');
+        }
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $formType = $_POST['form'] ?? 'plan';
+            if ($formType === 'parent') {
+                $planId = (int)($_POST['plan_id'] ?? 0);
+                if ($planId) {
+                    $parentType = $_POST['parent_type'] ?? 'animal';
+                    $data = [
+                        'plan_id' => $planId,
+                        'parent_type' => $parentType === 'virtual' ? 'virtual' : 'animal',
+                        'animal_id' => $_POST['animal_id'] ?? null,
+                        'name' => trim($_POST['name'] ?? ''),
+                        'sex' => trim($_POST['sex'] ?? ''),
+                        'species' => trim($_POST['species'] ?? ''),
+                        'genetics' => trim($_POST['genetics'] ?? ''),
+                        'notes' => $_POST['notes'] ?? null,
+                    ];
+                    if ($data['parent_type'] === 'animal' && empty($data['animal_id'])) {
+                        flash('error', 'Bitte ein Tier auswählen oder als virtuell kennzeichnen.');
+                    } else {
+                        if ($data['parent_type'] === 'virtual' && !$data['name']) {
+                            $data['name'] = 'Virtueller Elternteil';
+                        }
+                        add_breeding_parent($pdo, $data);
+                        flash('success', 'Elternteil hinzugefügt.');
+                    }
+                }
+                redirect('admin/breeding', ['edit_plan' => $planId]);
+            } else {
+                $data = [
+                    'title' => trim($_POST['title'] ?? ''),
+                    'season' => trim($_POST['season'] ?? ''),
+                    'notes' => $_POST['notes'] ?? null,
+                    'expected_genetics' => $_POST['expected_genetics'] ?? null,
+                    'incubation_notes' => $_POST['incubation_notes'] ?? null,
+                ];
+                if ($data['title']) {
+                    if (!empty($_POST['id'])) {
+                        update_breeding_plan($pdo, (int)$_POST['id'], $data);
+                        flash('success', 'Zuchtplan aktualisiert.');
+                        redirect('admin/breeding', ['edit_plan' => (int)$_POST['id']]);
+                    } else {
+                        $planId = create_breeding_plan($pdo, $data);
+                        flash('success', 'Zuchtplan erstellt.');
+                        redirect('admin/breeding', ['edit_plan' => $planId]);
+                    }
+                } else {
+                    flash('error', 'Titel wird benötigt.');
+                }
+            }
+        }
+        if (isset($_GET['delete_plan'])) {
+            delete_breeding_plan($pdo, (int)$_GET['delete_plan']);
+            flash('success', 'Zuchtplan gelöscht.');
+            redirect('admin/breeding');
+        }
+        if (isset($_GET['delete_parent'])) {
+            delete_breeding_parent($pdo, (int)$_GET['delete_parent']);
+            flash('success', 'Elternteil entfernt.');
+            redirect('admin/breeding', ['edit_plan' => (int)($_GET['plan'] ?? 0)]);
+        }
+        $settings = get_all_settings($pdo);
+        $animals = get_animals($pdo);
+        $breedingPlans = get_breeding_plans($pdo);
+        $editPlan = null;
+        if (isset($_GET['edit_plan'])) {
+            $editPlan = get_breeding_plan($pdo, (int)$_GET['edit_plan']);
+        }
+        $flashSuccess = flash('success');
+        $flashError = flash('error');
+        view('admin/breeding', compact('settings', 'animals', 'breedingPlans', 'editPlan', 'flashSuccess', 'flashError'));
+        break;
+
     case 'admin/adoption':
         require_login();
         if (!is_authorized('can_manage_adoptions')) {
@@ -181,6 +416,49 @@ switch ($route) {
         }
         $flashSuccess = flash('success');
         view('admin/adoption', compact('listings', 'animals', 'editListing', 'flashSuccess', 'settings'));
+        break;
+
+    case 'admin/care':
+        require_login();
+        if (!is_authorized('can_manage_settings')) {
+            flash('error', 'Keine Berechtigung.');
+            redirect('admin/dashboard');
+        }
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $data = [
+                'title' => trim($_POST['title'] ?? ''),
+                'slug' => trim($_POST['slug'] ?? ''),
+                'summary' => $_POST['summary'] ?? null,
+                'content' => $_POST['content'] ?? '',
+                'is_published' => isset($_POST['is_published']),
+            ];
+            if ($data['title'] && $data['content']) {
+                if (!empty($_POST['id'])) {
+                    update_care_article($pdo, (int)$_POST['id'], $data);
+                    flash('success', 'Artikel aktualisiert.');
+                } else {
+                    create_care_article($pdo, $data);
+                    flash('success', 'Artikel erstellt.');
+                }
+                redirect('admin/care');
+            } else {
+                flash('error', 'Titel und Inhalt werden benötigt.');
+            }
+        }
+        if (isset($_GET['delete'])) {
+            delete_care_article($pdo, (int)$_GET['delete']);
+            flash('success', 'Artikel gelöscht.');
+            redirect('admin/care');
+        }
+        $settings = get_all_settings($pdo);
+        $careArticles = get_care_articles($pdo);
+        $editArticle = null;
+        if (isset($_GET['edit'])) {
+            $editArticle = get_care_article($pdo, (int)$_GET['edit']);
+        }
+        $flashSuccess = flash('success');
+        $flashError = flash('error');
+        view('admin/care', compact('settings', 'careArticles', 'editArticle', 'flashSuccess', 'flashError'));
         break;
 
     case 'admin/inquiries':

--- a/public/views/admin/adoption.php
+++ b/public/views/admin/adoption.php
@@ -51,14 +51,14 @@
             <label>Art
                 <input type="text" name="species" value="<?= htmlspecialchars($editListing['species'] ?? '') ?>">
             </label>
-            <label>Genetik
-                <textarea name="genetics"><?= htmlspecialchars($editListing['genetics'] ?? '') ?></textarea>
-            </label>
             <label>Preis
                 <input type="text" name="price" value="<?= htmlspecialchars($editListing['price'] ?? '') ?>">
             </label>
+            <label>Genetik
+                <textarea name="genetics" class="rich-text"><?= htmlspecialchars($editListing['genetics'] ?? '') ?></textarea>
+            </label>
             <label>Beschreibung
-                <textarea name="description"><?= htmlspecialchars($editListing['description'] ?? '') ?></textarea>
+                <textarea name="description" class="rich-text"><?= htmlspecialchars($editListing['description'] ?? '') ?></textarea>
             </label>
             <label>Status
                 <select name="status">

--- a/public/views/admin/animals.php
+++ b/public/views/admin/animals.php
@@ -56,16 +56,16 @@
                 <input type="text" name="age" value="<?= htmlspecialchars($editAnimal['age'] ?? '') ?>">
             </label>
             <label>Genetik
-                <textarea name="genetics"><?= htmlspecialchars($editAnimal['genetics'] ?? '') ?></textarea>
+                <textarea name="genetics" class="rich-text"><?= htmlspecialchars($editAnimal['genetics'] ?? '') ?></textarea>
             </label>
             <label>Herkunft
                 <input type="text" name="origin" value="<?= htmlspecialchars($editAnimal['origin'] ?? '') ?>">
             </label>
             <label>Besonderheiten
-                <textarea name="special_notes"><?= htmlspecialchars($editAnimal['special_notes'] ?? '') ?></textarea>
+                <textarea name="special_notes" class="rich-text"><?= htmlspecialchars($editAnimal['special_notes'] ?? '') ?></textarea>
             </label>
             <label>Beschreibung
-                <textarea name="description"><?= htmlspecialchars($editAnimal['description'] ?? '') ?></textarea>
+                <textarea name="description" class="rich-text"><?= htmlspecialchars($editAnimal['description'] ?? '') ?></textarea>
             </label>
             <label>Bild
                 <input type="file" name="image" accept="image/*">

--- a/public/views/admin/breeding.php
+++ b/public/views/admin/breeding.php
@@ -1,0 +1,154 @@
+<?php include __DIR__ . '/../partials/header.php'; ?>
+<h1>Zuchtplanung</h1>
+<?php include __DIR__ . '/nav.php'; ?>
+<?php if ($flashSuccess): ?>
+    <div class="alert alert-success"><?= htmlspecialchars($flashSuccess) ?></div>
+<?php endif; ?>
+<?php if ($flashError): ?>
+    <div class="alert alert-error"><?= htmlspecialchars($flashError) ?></div>
+<?php endif; ?>
+<div class="grid" style="grid-template-columns:2fr 1fr;gap:2rem;align-items:start;">
+    <div class="card">
+        <h2>Aktive Pläne</h2>
+        <?php if (empty($breedingPlans)): ?>
+            <p>Noch keine Zuchtpläne angelegt.</p>
+        <?php else: ?>
+            <div class="stack">
+                <?php foreach ($breedingPlans as $plan): ?>
+                    <article class="plan-entry">
+                        <header class="plan-entry__header">
+                            <div>
+                                <h3><?= htmlspecialchars($plan['title']) ?></h3>
+                                <p class="text-muted">
+                                    <?= htmlspecialchars($plan['season'] ?: 'Saison offen') ?>
+                                </p>
+                            </div>
+                            <div class="plan-entry__actions">
+                                <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/breeding&edit_plan=<?= (int)$plan['id'] ?>">Bearbeiten</a>
+                                <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/breeding&delete_plan=<?= (int)$plan['id'] ?>" onclick="return confirm('Zuchtplan wirklich löschen?');">Löschen</a>
+                            </div>
+                        </header>
+                        <?php if (!empty($plan['expected_genetics'])): ?>
+                            <div class="plan-entry__section">
+                                <strong>Erwartete Genetik:</strong>
+                                <div class="rich-text-content"><?= render_rich_text($plan['expected_genetics']) ?></div>
+                            </div>
+                        <?php endif; ?>
+                        <?php if (!empty($plan['incubation_notes'])): ?>
+                            <div class="plan-entry__section">
+                                <strong>Inkubation:</strong>
+                                <div class="rich-text-content"><?= render_rich_text($plan['incubation_notes']) ?></div>
+                            </div>
+                        <?php endif; ?>
+                        <?php if (!empty($plan['notes'])): ?>
+                            <div class="rich-text-content"><?= render_rich_text($plan['notes']) ?></div>
+                        <?php endif; ?>
+                        <h4>Elterntiere</h4>
+                        <?php if (empty($plan['parents'])): ?>
+                            <p class="text-muted">Noch keine Eltern zugeordnet.</p>
+                        <?php else: ?>
+                            <ul class="plan-parents">
+                                <?php foreach ($plan['parents'] as $parent): ?>
+                                    <li>
+                                        <div class="plan-parent__title">
+                                            <strong><?= htmlspecialchars($parent['parent_type'] === 'virtual' ? ($parent['name'] ?: 'Virtuell') : ($parent['animal_name'] ?? $parent['name'] ?? 'Unbenannt')) ?></strong>
+                                            <?php if ($parent['sex']): ?>
+                                                <span class="badge"><?= htmlspecialchars(strtoupper($parent['sex'])) ?></span>
+                                            <?php endif; ?>
+                                        </div>
+                                        <div class="text-muted">
+                                            <?= htmlspecialchars($parent['parent_type'] === 'virtual' ? 'Virtuelles Tier' : 'Bestandstier') ?>
+                                        </div>
+                                        <?php if ($parent['parent_type'] === 'animal' && $parent['animal_species']): ?>
+                                            <div><?= htmlspecialchars($parent['animal_species']) ?></div>
+                                        <?php elseif (!empty($parent['species'])): ?>
+                                            <div><?= htmlspecialchars($parent['species']) ?></div>
+                                        <?php endif; ?>
+                                        <?php if (!empty($parent['animal_genetics']) || !empty($parent['genetics'])): ?>
+                                            <div><strong>Genetik:</strong> <?= htmlspecialchars($parent['animal_genetics'] ?? $parent['genetics']) ?></div>
+                                        <?php endif; ?>
+                                        <?php if (!empty($parent['notes'])): ?>
+                                            <div><?= nl2br(htmlspecialchars($parent['notes'])) ?></div>
+                                        <?php endif; ?>
+                                        <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/breeding&delete_parent=<?= (int)$parent['id'] ?>&plan=<?= (int)$plan['id'] ?>" onclick="return confirm('Elternteil entfernen?');">Entfernen</a>
+                                    </li>
+                                <?php endforeach; ?>
+                            </ul>
+                        <?php endif; ?>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+        <?php endif; ?>
+    </div>
+    <div class="card">
+        <h2><?= $editPlan ? 'Zuchtplan bearbeiten' : 'Neuer Zuchtplan' ?></h2>
+        <form method="post">
+            <input type="hidden" name="form" value="plan">
+            <?php if ($editPlan): ?>
+                <input type="hidden" name="id" value="<?= (int)$editPlan['id'] ?>">
+            <?php endif; ?>
+            <label>Titel
+                <input type="text" name="title" value="<?= htmlspecialchars($editPlan['title'] ?? '') ?>" required>
+            </label>
+            <label>Saison / Jahr
+                <input type="text" name="season" value="<?= htmlspecialchars($editPlan['season'] ?? '') ?>" placeholder="z.B. 2024/2025">
+            </label>
+            <label>Erwartete Genetik
+                <textarea name="expected_genetics" class="rich-text"><?= htmlspecialchars($editPlan['expected_genetics'] ?? '') ?></textarea>
+            </label>
+            <label>Inkubationsnotizen
+                <textarea name="incubation_notes" class="rich-text"><?= htmlspecialchars($editPlan['incubation_notes'] ?? '') ?></textarea>
+            </label>
+            <label>Allgemeine Notizen
+                <textarea name="notes" class="rich-text"><?= htmlspecialchars($editPlan['notes'] ?? '') ?></textarea>
+            </label>
+            <button type="submit">Zuchtplan speichern</button>
+        </form>
+        <?php if (!empty($breedingPlans)): ?>
+            <hr style="margin:2rem 0;opacity:0.3;">
+            <h3>Elterntier hinzufügen</h3>
+            <form method="post">
+                <input type="hidden" name="form" value="parent">
+                <label>Zuchtplan
+                    <select name="plan_id" required>
+                        <?php foreach ($breedingPlans as $planOption): ?>
+                            <option value="<?= (int)$planOption['id'] ?>" <?= (($editPlan['id'] ?? 0) == $planOption['id']) ? 'selected' : '' ?>><?= htmlspecialchars($planOption['title']) ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </label>
+                <label>Eltern-Typ
+                    <select name="parent_type">
+                        <option value="animal">Tier aus Bestand</option>
+                        <option value="virtual">Virtuelles Tier</option>
+                    </select>
+                </label>
+                <label>Tier aus Bestand
+                    <select name="animal_id">
+                        <option value="">— auswählen —</option>
+                        <?php foreach ($animals as $animal): ?>
+                            <option value="<?= (int)$animal['id'] ?>"><?= htmlspecialchars($animal['name']) ?> (<?= htmlspecialchars($animal['species']) ?>)</option>
+                        <?php endforeach; ?>
+                    </select>
+                </label>
+                <label>Name (für virtuelle Eltern)
+                    <input type="text" name="name" value="">
+                </label>
+                <label>Geschlecht (m/w)
+                    <input type="text" name="sex" value="">
+                </label>
+                <label>Art / Lokalität
+                    <input type="text" name="species" value="">
+                </label>
+                <label>Genetik
+                    <textarea name="genetics"></textarea>
+                </label>
+                <label>Notizen
+                    <textarea name="notes"></textarea>
+                </label>
+                <button type="submit">Elternteil speichern</button>
+            </form>
+        <?php endif; ?>
+    </div>
+</div>
+<?php include __DIR__ . '/../partials/footer.php'; ?>
+

--- a/public/views/admin/care.php
+++ b/public/views/admin/care.php
@@ -1,0 +1,69 @@
+<?php include __DIR__ . '/../partials/header.php'; ?>
+<h1>Pflegeleitfaden</h1>
+<?php include __DIR__ . '/nav.php'; ?>
+<?php if ($flashSuccess): ?>
+    <div class="alert alert-success"><?= htmlspecialchars($flashSuccess) ?></div>
+<?php endif; ?>
+<?php if ($flashError): ?>
+    <div class="alert alert-error"><?= htmlspecialchars($flashError) ?></div>
+<?php endif; ?>
+<div class="grid" style="grid-template-columns:2fr 1fr;gap:2rem;align-items:start;">
+    <div class="card">
+        <h2>Artikelübersicht</h2>
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>Titel</th>
+                    <th>Slug</th>
+                    <th>Status</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($careArticles as $article): ?>
+                    <tr>
+                        <td><?= htmlspecialchars($article['title']) ?></td>
+                        <td><?= htmlspecialchars($article['slug']) ?></td>
+                        <td>
+                            <?php if ($article['is_published']): ?>
+                                <span class="badge">veröffentlicht</span>
+                            <?php else: ?>
+                                <span class="badge">Entwurf</span>
+                            <?php endif; ?>
+                        </td>
+                        <td>
+                            <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/care&edit=<?= (int)$article['id'] ?>">Bearbeiten</a>
+                            <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/care&delete=<?= (int)$article['id'] ?>" onclick="return confirm('Artikel wirklich löschen?');">Löschen</a>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+    <div class="card">
+        <h2><?= $editArticle ? 'Artikel bearbeiten' : 'Neuer Artikel' ?></h2>
+        <form method="post">
+            <?php if ($editArticle): ?>
+                <input type="hidden" name="id" value="<?= (int)$editArticle['id'] ?>">
+            <?php endif; ?>
+            <label>Titel
+                <input type="text" name="title" value="<?= htmlspecialchars($editArticle['title'] ?? '') ?>" required>
+            </label>
+            <label>Slug (optional)
+                <input type="text" name="slug" value="<?= htmlspecialchars($editArticle['slug'] ?? '') ?>">
+            </label>
+            <label>Kurzbeschreibung
+                <textarea name="summary" rows="4"><?= htmlspecialchars($editArticle['summary'] ?? '') ?></textarea>
+            </label>
+            <label>Inhalt
+                <textarea name="content" class="rich-text" required><?= htmlspecialchars($editArticle['content'] ?? '') ?></textarea>
+            </label>
+            <label style="display:flex;align-items:center;gap:0.5rem;">
+                <input type="checkbox" name="is_published" value="1" <?= !empty($editArticle['is_published']) ? 'checked' : '' ?>> veröffentlichen
+            </label>
+            <button type="submit">Speichern</button>
+        </form>
+    </div>
+</div>
+<?php include __DIR__ . '/../partials/footer.php'; ?>
+

--- a/public/views/admin/dashboard.php
+++ b/public/views/admin/dashboard.php
@@ -14,6 +14,22 @@
         <h3>Neue Anfragen</h3>
         <p><?= count($inquiries) ?> Nachrichten</p>
     </div>
+    <div class="card">
+        <h3>Seiten</h3>
+        <p><?= count($pages) ?> Einträge</p>
+    </div>
+    <div class="card">
+        <h3>News</h3>
+        <p><?= count($newsPosts) ?> Beiträge</p>
+    </div>
+    <div class="card">
+        <h3>Zuchtpläne</h3>
+        <p><?= count($breedingPlans) ?> Projekte</p>
+    </div>
+    <div class="card">
+        <h3>Pflegeartikel</h3>
+        <p><?= count($careArticles) ?> Artikel</p>
+    </div>
 </div>
 
 <section style="margin-top:2rem;">

--- a/public/views/admin/nav.php
+++ b/public/views/admin/nav.php
@@ -1,9 +1,15 @@
 <div class="admin-nav">
     <a href="<?= BASE_URL ?>/index.php?route=admin/dashboard" class="<?= $currentRoute === 'admin/dashboard' ? 'active' : '' ?>">Übersicht</a>
     <a href="<?= BASE_URL ?>/index.php?route=admin/animals" class="<?= $currentRoute === 'admin/animals' ? 'active' : '' ?>">Tiere</a>
+    <?php if (is_authorized('can_manage_animals')): ?>
+        <a href="<?= BASE_URL ?>/index.php?route=admin/breeding" class="<?= $currentRoute === 'admin/breeding' ? 'active' : '' ?>">Zuchtplanung</a>
+    <?php endif; ?>
     <a href="<?= BASE_URL ?>/index.php?route=admin/adoption" class="<?= $currentRoute === 'admin/adoption' ? 'active' : '' ?>">Tierabgabe</a>
     <a href="<?= BASE_URL ?>/index.php?route=admin/inquiries" class="<?= $currentRoute === 'admin/inquiries' ? 'active' : '' ?>">Anfragen</a>
     <?php if (is_authorized('can_manage_settings')): ?>
+        <a href="<?= BASE_URL ?>/index.php?route=admin/pages" class="<?= $currentRoute === 'admin/pages' ? 'active' : '' ?>">Seiten</a>
+        <a href="<?= BASE_URL ?>/index.php?route=admin/news" class="<?= $currentRoute === 'admin/news' ? 'active' : '' ?>">Neuigkeiten</a>
+        <a href="<?= BASE_URL ?>/index.php?route=admin/care" class="<?= $currentRoute === 'admin/care' ? 'active' : '' ?>">Pflegeleitfaden</a>
         <a href="<?= BASE_URL ?>/index.php?route=admin/settings" class="<?= $currentRoute === 'admin/settings' ? 'active' : '' ?>">Einstellungen</a>
     <?php endif; ?>
     <?php if (current_user()['role'] === 'admin'): ?>

--- a/public/views/admin/news.php
+++ b/public/views/admin/news.php
@@ -1,0 +1,72 @@
+<?php include __DIR__ . '/../partials/header.php'; ?>
+<h1>Neuigkeiten</h1>
+<?php include __DIR__ . '/nav.php'; ?>
+<?php if ($flashSuccess): ?>
+    <div class="alert alert-success"><?= htmlspecialchars($flashSuccess) ?></div>
+<?php endif; ?>
+<?php if ($flashError): ?>
+    <div class="alert alert-error"><?= htmlspecialchars($flashError) ?></div>
+<?php endif; ?>
+<div class="grid" style="grid-template-columns:2fr 1fr;gap:2rem;align-items:start;">
+    <div class="card">
+        <h2>Veröffentlichte Beiträge</h2>
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>Titel</th>
+                    <th>Status</th>
+                    <th>Veröffentlicht</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($newsPosts as $post): ?>
+                    <tr>
+                        <td><?= htmlspecialchars($post['title']) ?></td>
+                        <td>
+                            <?php if ($post['is_published']): ?>
+                                <span class="badge">online</span>
+                            <?php else: ?>
+                                <span class="badge">Entwurf</span>
+                            <?php endif; ?>
+                        </td>
+                        <td><?= htmlspecialchars($post['published_at'] ?? '—') ?></td>
+                        <td>
+                            <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/news&edit=<?= (int)$post['id'] ?>">Bearbeiten</a>
+                            <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/news&delete=<?= (int)$post['id'] ?>" onclick="return confirm('Beitrag wirklich löschen?');">Löschen</a>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+    <div class="card">
+        <h2><?= $editPost ? 'Beitrag bearbeiten' : 'Neuer Beitrag' ?></h2>
+        <form method="post">
+            <?php if ($editPost): ?>
+                <input type="hidden" name="id" value="<?= (int)$editPost['id'] ?>">
+            <?php endif; ?>
+            <label>Titel
+                <input type="text" name="title" value="<?= htmlspecialchars($editPost['title'] ?? '') ?>" required>
+            </label>
+            <label>Slug (optional)
+                <input type="text" name="slug" value="<?= htmlspecialchars($editPost['slug'] ?? '') ?>">
+            </label>
+            <label>Kurzfassung
+                <textarea name="excerpt" rows="4"><?= htmlspecialchars($editPost['excerpt'] ?? '') ?></textarea>
+            </label>
+            <label>Inhalt
+                <textarea name="content" class="rich-text" required><?= htmlspecialchars($editPost['content'] ?? '') ?></textarea>
+            </label>
+            <label>Veröffentlicht am
+                <input type="datetime-local" name="published_at" value="<?= !empty($editPost['published_at']) ? date('Y-m-d\TH:i', strtotime($editPost['published_at'])) : '' ?>">
+            </label>
+            <label style="display:flex;align-items:center;gap:0.5rem;">
+                <input type="checkbox" name="is_published" value="1" <?= !empty($editPost['is_published']) ? 'checked' : '' ?>> sofort veröffentlichen
+            </label>
+            <button type="submit">Speichern</button>
+        </form>
+    </div>
+</div>
+<?php include __DIR__ . '/../partials/footer.php'; ?>
+

--- a/public/views/admin/pages.php
+++ b/public/views/admin/pages.php
@@ -1,0 +1,66 @@
+<?php include __DIR__ . '/../partials/header.php'; ?>
+<h1>Seiten verwalten</h1>
+<?php include __DIR__ . '/nav.php'; ?>
+<?php if ($flashSuccess): ?>
+    <div class="alert alert-success"><?= htmlspecialchars($flashSuccess) ?></div>
+<?php endif; ?>
+<?php if ($flashError): ?>
+    <div class="alert alert-error"><?= htmlspecialchars($flashError) ?></div>
+<?php endif; ?>
+<div class="grid" style="grid-template-columns:2fr 1fr;gap:2rem;align-items:start;">
+    <div class="card">
+        <h2>Bestehende Seiten</h2>
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>Titel</th>
+                    <th>Slug</th>
+                    <th>Status</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($pages as $pageItem): ?>
+                    <tr>
+                        <td><?= htmlspecialchars($pageItem['title']) ?></td>
+                        <td><?= htmlspecialchars($pageItem['slug']) ?></td>
+                        <td>
+                            <?php if ($pageItem['is_published']): ?>
+                                <span class="badge">veröffentlicht</span>
+                            <?php else: ?>
+                                <span class="badge">Entwurf</span>
+                            <?php endif; ?>
+                        </td>
+                        <td>
+                            <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/pages&edit=<?= (int)$pageItem['id'] ?>">Bearbeiten</a>
+                            <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/pages&delete=<?= (int)$pageItem['id'] ?>" onclick="return confirm('Seite wirklich löschen?');">Löschen</a>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+    <div class="card">
+        <h2><?= $editPage ? 'Seite bearbeiten' : 'Neue Seite' ?></h2>
+        <form method="post">
+            <?php if ($editPage): ?>
+                <input type="hidden" name="id" value="<?= (int)$editPage['id'] ?>">
+            <?php endif; ?>
+            <label>Titel
+                <input type="text" name="title" value="<?= htmlspecialchars($editPage['title'] ?? '') ?>" required>
+            </label>
+            <label>Slug (optional)
+                <input type="text" name="slug" value="<?= htmlspecialchars($editPage['slug'] ?? '') ?>" placeholder="automatisch aus Titel">
+            </label>
+            <label>Inhalt
+                <textarea name="content" class="rich-text" required><?= htmlspecialchars($editPage['content'] ?? '') ?></textarea>
+            </label>
+            <label style="display:flex;align-items:center;gap:0.5rem;">
+                <input type="checkbox" name="is_published" value="1" <?= !empty($editPage['is_published']) ? 'checked' : '' ?>> veröffentlichen
+            </label>
+            <button type="submit">Speichern</button>
+        </form>
+    </div>
+</div>
+<?php include __DIR__ . '/../partials/footer.php'; ?>
+

--- a/public/views/admin/settings.php
+++ b/public/views/admin/settings.php
@@ -13,13 +13,13 @@
             <input type="text" name="site_tagline" value="<?= htmlspecialchars($settings['site_tagline'] ?? '') ?>">
         </label>
         <label>Hero-Einleitung
-            <textarea name="hero_intro"><?= htmlspecialchars($settings['hero_intro'] ?? '') ?></textarea>
+            <textarea name="hero_intro" class="rich-text"><?= htmlspecialchars($settings['hero_intro'] ?? '') ?></textarea>
         </label>
         <label>Abgabe Intro
-            <textarea name="adoption_intro"><?= htmlspecialchars($settings['adoption_intro'] ?? '') ?></textarea>
+            <textarea name="adoption_intro" class="rich-text"><?= htmlspecialchars($settings['adoption_intro'] ?? '') ?></textarea>
         </label>
         <label>Footer Text
-            <textarea name="footer_text"><?= htmlspecialchars($settings['footer_text'] ?? '') ?></textarea>
+            <textarea name="footer_text" class="rich-text"><?= htmlspecialchars($settings['footer_text'] ?? '') ?></textarea>
         </label>
         <label>Kontakt E-Mail
             <input type="email" name="contact_email" value="<?= htmlspecialchars($settings['contact_email'] ?? '') ?>">

--- a/public/views/adoption/index.php
+++ b/public/views/adoption/index.php
@@ -1,6 +1,6 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
 <h1>Tierabgabe</h1>
-<p><?= nl2br(htmlspecialchars($settings['adoption_intro'] ?? '')) ?></p>
+<div class="rich-text-content"><?= render_rich_text($settings['adoption_intro'] ?? '') ?></div>
 <?php if ($flashSuccess): ?>
     <div class="alert alert-success"><?= htmlspecialchars($flashSuccess) ?></div>
 <?php endif; ?>
@@ -25,7 +25,7 @@
                 <p><strong>Preis:</strong> <?= htmlspecialchars($listing['price']) ?></p>
             <?php endif; ?>
             <?php if (!empty($listing['description'])): ?>
-                <p><?= nl2br(htmlspecialchars($listing['description'])) ?></p>
+                <div class="rich-text-content"><?= render_rich_text($listing['description']) ?></div>
             <?php endif; ?>
             <form method="post" class="card" style="background:rgba(148,163,184,0.08);margin-top:1rem;">
                 <input type="hidden" name="listing_id" value="<?= (int)$listing['id'] ?>">

--- a/public/views/animals/index.php
+++ b/public/views/animals/index.php
@@ -20,7 +20,7 @@
                 <p><strong>Herkunft:</strong> <?= htmlspecialchars($animal['origin']) ?></p>
             <?php endif; ?>
             <?php if (!empty($animal['description'])): ?>
-                <p><?= nl2br(htmlspecialchars($animal['description'])) ?></p>
+                <div class="rich-text-content"><?= render_rich_text($animal['description']) ?></div>
             <?php endif; ?>
         </article>
     <?php endforeach; ?>

--- a/public/views/animals/my_animals.php
+++ b/public/views/animals/my_animals.php
@@ -23,7 +23,7 @@
                     <p><strong>Herkunft:</strong> <?= htmlspecialchars($animal['origin']) ?></p>
                 <?php endif; ?>
                 <?php if (!empty($animal['special_notes'])): ?>
-                    <p><?= nl2br(htmlspecialchars($animal['special_notes'])) ?></p>
+                    <div class="rich-text-content"><?= render_rich_text($animal['special_notes']) ?></div>
                 <?php endif; ?>
             </article>
         <?php endforeach; ?>

--- a/public/views/breeding/index.php
+++ b/public/views/breeding/index.php
@@ -1,0 +1,66 @@
+<?php include __DIR__ . '/../partials/header.php'; ?>
+<h1>Zuchtplanung</h1>
+<p class="text-muted">Interne Übersicht über geplante Verpaarungen und Inkubationsschritte.</p>
+<div class="grid" style="gap:2rem;margin-top:2rem;">
+    <?php foreach ($breedingPlans as $plan): ?>
+        <article class="card">
+            <header style="display:flex;justify-content:space-between;align-items:center;gap:1rem;">
+                <div>
+                    <h2><?= htmlspecialchars($plan['title']) ?></h2>
+                    <p class="text-muted">Saison: <?= htmlspecialchars($plan['season'] ?: 'offen') ?></p>
+                </div>
+            </header>
+            <?php if (!empty($plan['expected_genetics'])): ?>
+                <div class="plan-entry__section">
+                    <strong>Erwartete Genetik:</strong>
+                    <div class="rich-text-content"><?= render_rich_text($plan['expected_genetics']) ?></div>
+                </div>
+            <?php endif; ?>
+            <?php if (!empty($plan['incubation_notes'])): ?>
+                <div class="plan-entry__section">
+                    <strong>Inkubationsnotizen:</strong>
+                    <div class="rich-text-content"><?= render_rich_text($plan['incubation_notes']) ?></div>
+                </div>
+            <?php endif; ?>
+            <?php if (!empty($plan['notes'])): ?>
+                <div class="plan-entry__section">
+                    <strong>Notizen:</strong>
+                    <div class="rich-text-content"><?= render_rich_text($plan['notes']) ?></div>
+                </div>
+            <?php endif; ?>
+            <h3>Elterntiere</h3>
+            <?php if (empty($plan['parents'])): ?>
+                <p class="text-muted">Noch keine Eltern hinterlegt.</p>
+            <?php else: ?>
+                <ul class="plan-parents">
+                    <?php foreach ($plan['parents'] as $parent): ?>
+                        <li>
+                            <div class="plan-parent__title">
+                                <strong><?= htmlspecialchars($parent['parent_type'] === 'virtual' ? ($parent['name'] ?: 'Virtuell') : ($parent['animal_name'] ?? $parent['name'] ?? 'Unbenannt')) ?></strong>
+                                <?php if ($parent['sex']): ?>
+                                    <span class="badge"><?= htmlspecialchars(strtoupper($parent['sex'])) ?></span>
+                                <?php endif; ?>
+                            </div>
+                            <div class="text-muted">
+                                <?= htmlspecialchars($parent['parent_type'] === 'virtual' ? 'Virtuelles Tier' : 'Bestandstier') ?>
+                            </div>
+                            <?php if ($parent['parent_type'] === 'animal' && $parent['animal_species']): ?>
+                                <div><?= htmlspecialchars($parent['animal_species']) ?></div>
+                            <?php elseif (!empty($parent['species'])): ?>
+                                <div><?= htmlspecialchars($parent['species']) ?></div>
+                            <?php endif; ?>
+                            <?php if (!empty($parent['animal_genetics']) || !empty($parent['genetics'])): ?>
+                                <div><strong>Genetik:</strong> <?= htmlspecialchars($parent['animal_genetics'] ?? $parent['genetics']) ?></div>
+                            <?php endif; ?>
+                            <?php if (!empty($parent['notes'])): ?>
+                                <div><?= nl2br(htmlspecialchars($parent['notes'])) ?></div>
+                            <?php endif; ?>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+            <?php endif; ?>
+        </article>
+    <?php endforeach; ?>
+</div>
+<?php include __DIR__ . '/../partials/footer.php'; ?>
+

--- a/public/views/care/index.php
+++ b/public/views/care/index.php
@@ -1,0 +1,16 @@
+<?php include __DIR__ . '/../partials/header.php'; ?>
+<h1>Pflegeleitfaden</h1>
+<p class="text-muted">Wissensdatenbank mit Pflegeprofilen, Technik- und Ernährungsrichtlinien.</p>
+<div class="grid cards" style="margin-top:2rem;">
+    <?php foreach ($careArticles as $article): ?>
+        <article class="card">
+            <h2><?= htmlspecialchars($article['title']) ?></h2>
+            <?php if (!empty($article['summary'])): ?>
+                <p><?= nl2br(htmlspecialchars($article['summary'])) ?></p>
+            <?php endif; ?>
+            <a class="btn" href="<?= BASE_URL ?>/index.php?route=care-article&amp;slug=<?= urlencode($article['slug']) ?>">Artikel lesen</a>
+        </article>
+    <?php endforeach; ?>
+</div>
+<?php include __DIR__ . '/../partials/footer.php'; ?>
+

--- a/public/views/care/show.php
+++ b/public/views/care/show.php
@@ -1,0 +1,10 @@
+<?php include __DIR__ . '/../partials/header.php'; ?>
+<article class="card">
+    <h1><?= htmlspecialchars($article['title']) ?></h1>
+    <?php if (!empty($article['summary'])): ?>
+        <p class="text-muted"><?= nl2br(htmlspecialchars($article['summary'])) ?></p>
+    <?php endif; ?>
+    <div class="rich-text-content"><?= render_rich_text($article['content']) ?></div>
+</article>
+<?php include __DIR__ . '/../partials/footer.php'; ?>
+

--- a/public/views/home.php
+++ b/public/views/home.php
@@ -2,7 +2,7 @@
 <section class="hero">
     <div>
         <h1><?= htmlspecialchars($settings['site_title'] ?? APP_NAME) ?></h1>
-        <p><?= nl2br(htmlspecialchars($settings['hero_intro'] ?? '')) ?></p>
+        <div class="rich-text-content"><?= render_rich_text($settings['hero_intro'] ?? '') ?></div>
     </div>
     <div>
         <span class="badge">Pflegeleitfaden</span>
@@ -30,7 +30,7 @@
                     <p><?= htmlspecialchars($animal['genetics']) ?></p>
                 <?php endif; ?>
                 <?php if (!empty($animal['special_notes'])): ?>
-                    <p><?= nl2br(htmlspecialchars($animal['special_notes'])) ?></p>
+                    <div class="rich-text-content"><?= render_rich_text($animal['special_notes']) ?></div>
                 <?php endif; ?>
             </article>
         <?php endforeach; ?>
@@ -40,7 +40,7 @@
 
 <section style="margin-top:3rem;">
     <h2>Tiervermittlung</h2>
-    <p><?= nl2br(htmlspecialchars($settings['adoption_intro'] ?? '')) ?></p>
+    <div class="rich-text-content"><?= render_rich_text($settings['adoption_intro'] ?? '') ?></div>
     <div class="grid cards">
         <?php foreach ($listings as $listing): ?>
             <article class="card">
@@ -59,7 +59,7 @@
                     <p><strong>Preis:</strong> <?= htmlspecialchars($listing['price']) ?></p>
                 <?php endif; ?>
                 <?php if (!empty($listing['description'])): ?>
-                    <p><?= nl2br(htmlspecialchars($listing['description'])) ?></p>
+                    <div class="rich-text-content"><?= render_rich_text($listing['description']) ?></div>
                 <?php endif; ?>
                 <?php if (!empty($settings['contact_email'])): ?>
                     <a class="btn" href="mailto:<?= htmlspecialchars($settings['contact_email']) ?>?subject=Anfrage%20<?= urlencode($listing['title']) ?>">Direkt anfragen</a>
@@ -68,4 +68,47 @@
         <?php endforeach; ?>
     </div>
 </section>
+<?php if (!empty($latestNews)): ?>
+<section style="margin-top:3rem;">
+    <h2>Neuigkeiten</h2>
+    <div class="grid cards">
+        <?php foreach ($latestNews as $post): ?>
+            <article class="card">
+                <h3><?= htmlspecialchars($post['title']) ?></h3>
+                <?php if (!empty($post['published_at'])): ?>
+                    <p class="text-muted"><?= date('d.m.Y', strtotime($post['published_at'])) ?></p>
+                <?php endif; ?>
+                <?php if (!empty($post['excerpt'])): ?>
+                    <p><?= nl2br(htmlspecialchars($post['excerpt'])) ?></p>
+                <?php endif; ?>
+                <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=news&amp;slug=<?= urlencode($post['slug']) ?>">Details</a>
+            </article>
+        <?php endforeach; ?>
+    </div>
+    <div style="margin-top:1rem;">
+        <a class="btn" href="<?= BASE_URL ?>/index.php?route=news">Alle Meldungen anzeigen</a>
+    </div>
+</section>
+<?php endif; ?>
+
+<?php if (!empty($careHighlights)): ?>
+<section style="margin-top:3rem;">
+    <h2>Pflegewissen</h2>
+    <div class="grid cards">
+        <?php foreach ($careHighlights as $article): ?>
+            <article class="card">
+                <h3><?= htmlspecialchars($article['title']) ?></h3>
+                <?php if (!empty($article['summary'])): ?>
+                    <p><?= nl2br(htmlspecialchars($article['summary'])) ?></p>
+                <?php endif; ?>
+                <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=care-article&amp;slug=<?= urlencode($article['slug']) ?>">Leitfaden öffnen</a>
+            </article>
+        <?php endforeach; ?>
+    </div>
+    <div style="margin-top:1rem;">
+        <a class="btn" href="<?= BASE_URL ?>/index.php?route=care-guide">Zur Wissenssammlung</a>
+    </div>
+</section>
+<?php endif; ?>
+
 <?php include __DIR__ . '/partials/footer.php'; ?>

--- a/public/views/news/index.php
+++ b/public/views/news/index.php
@@ -1,0 +1,19 @@
+<?php include __DIR__ . '/../partials/header.php'; ?>
+<h1>Neuigkeiten</h1>
+<p class="text-muted">Aktuelle Updates aus dem FeroxZ Center.</p>
+<div class="grid cards" style="margin-top:2rem;">
+    <?php foreach ($newsPosts as $post): ?>
+        <article class="card">
+            <h2><?= htmlspecialchars($post['title']) ?></h2>
+            <?php if (!empty($post['published_at'])): ?>
+                <p class="text-muted">Veröffentlicht am <?= date('d.m.Y H:i', strtotime($post['published_at'])) ?></p>
+            <?php endif; ?>
+            <?php if (!empty($post['excerpt'])): ?>
+                <p><?= nl2br(htmlspecialchars($post['excerpt'])) ?></p>
+            <?php endif; ?>
+            <a class="btn" href="<?= BASE_URL ?>/index.php?route=news&amp;slug=<?= urlencode($post['slug']) ?>">Weiterlesen</a>
+        </article>
+    <?php endforeach; ?>
+</div>
+<?php include __DIR__ . '/../partials/footer.php'; ?>
+

--- a/public/views/news/show.php
+++ b/public/views/news/show.php
@@ -1,0 +1,13 @@
+<?php include __DIR__ . '/../partials/header.php'; ?>
+<article class="card">
+    <h1><?= htmlspecialchars($post['title']) ?></h1>
+    <?php if (!empty($post['published_at'])): ?>
+        <p class="text-muted">Veröffentlicht am <?= date('d.m.Y H:i', strtotime($post['published_at'])) ?></p>
+    <?php endif; ?>
+    <?php if (!empty($post['excerpt'])): ?>
+        <p><em><?= nl2br(htmlspecialchars($post['excerpt'])) ?></em></p>
+    <?php endif; ?>
+    <div class="rich-text-content"><?= render_rich_text($post['content']) ?></div>
+</article>
+<?php include __DIR__ . '/../partials/footer.php'; ?>
+

--- a/public/views/pages/show.php
+++ b/public/views/pages/show.php
@@ -1,0 +1,7 @@
+<?php include __DIR__ . '/../partials/header.php'; ?>
+<article class="card">
+    <h1><?= htmlspecialchars($page['title']) ?></h1>
+    <div class="rich-text-content"><?= render_rich_text($page['content']) ?></div>
+</article>
+<?php include __DIR__ . '/../partials/footer.php'; ?>
+

--- a/public/views/partials/footer.php
+++ b/public/views/partials/footer.php
@@ -5,5 +5,8 @@
         <?= nl2br(htmlspecialchars($settings['footer_text'] ?? '')) ?>
     </div>
 </footer>
+<?php if (isset($currentRoute) && str_starts_with($currentRoute, 'admin/')): ?>
+    <script src="<?= asset('admin.js') ?>"></script>
+<?php endif; ?>
 </body>
 </html>

--- a/public/views/partials/header.php
+++ b/public/views/partials/header.php
@@ -19,11 +19,18 @@
             <div class="nav-links">
                 <a href="<?= BASE_URL ?>/index.php" class="<?= ($currentRoute === 'home') ? 'active' : '' ?>">Start</a>
                 <a href="<?= BASE_URL ?>/index.php?route=animals" class="<?= ($currentRoute === 'animals') ? 'active' : '' ?>">Tierübersicht</a>
-                <?php if (current_user()): ?>
-                    <a href="<?= BASE_URL ?>/index.php?route=my-animals" class="<?= ($currentRoute === 'my-animals') ? 'active' : '' ?>">Meine Tiere</a>
-                <?php endif; ?>
+                <a href="<?= BASE_URL ?>/index.php?route=news" class="<?= ($currentRoute === 'news') ? 'active' : '' ?>">Neuigkeiten</a>
+                <a href="<?= BASE_URL ?>/index.php?route=care-guide" class="<?= ($currentRoute === 'care-guide' || $currentRoute === 'care-article') ? 'active' : '' ?>">Pflegeleitfaden</a>
+                <?php foreach (($navCareArticles ?? []) as $careNav): ?>
+                    <a href="<?= BASE_URL ?>/index.php?route=care-article&amp;slug=<?= urlencode($careNav['slug']) ?>" class="<?= ($currentRoute === 'care-article' && ($activeCareSlug ?? '') === $careNav['slug']) ? 'active' : '' ?>"><?= htmlspecialchars($careNav['title']) ?></a>
+                <?php endforeach; ?>
+                <?php foreach (($navPages ?? []) as $navPage): ?>
+                    <a href="<?= BASE_URL ?>/index.php?route=page&amp;slug=<?= urlencode($navPage['slug']) ?>" class="<?= ($currentRoute === 'page' && ($activePageSlug ?? '') === $navPage['slug']) ? 'active' : '' ?>"><?= htmlspecialchars($navPage['title']) ?></a>
+                <?php endforeach; ?>
                 <a href="<?= BASE_URL ?>/index.php?route=adoption" class="<?= ($currentRoute === 'adoption') ? 'active' : '' ?>">Tierabgabe</a>
                 <?php if (current_user()): ?>
+                    <a href="<?= BASE_URL ?>/index.php?route=my-animals" class="<?= ($currentRoute === 'my-animals') ? 'active' : '' ?>">Meine Tiere</a>
+                    <a href="<?= BASE_URL ?>/index.php?route=breeding" class="<?= ($currentRoute === 'breeding') ? 'active' : '' ?>">Zuchtplanung</a>
                     <a href="<?= BASE_URL ?>/index.php?route=admin/dashboard" class="<?= str_starts_with($currentRoute, 'admin/') ? 'active' : '' ?>">Admin</a>
                     <a href="<?= BASE_URL ?>/index.php?route=logout">Logout</a>
                 <?php else: ?>


### PR DESCRIPTION
## Summary
- add SQLite tables and PHP modules for static pages, news posts, breeding plans/parents, and care articles with defaults
- wire new public and admin routes for news, pages, breeding planner, and the care guide including WYSIWYG editing support
- refresh navigation and home page sections to surface news highlights, care wiki entries, and breeding access for logged-in users

## Testing
- `find public app -name "*.php" -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68dc188ffde8832b9cbdc63522c240f3