### PR TITLE
Align genetics calculator with MorphMarket-style UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ uploads/*
 .env
 .idea/
 .vscode/
+node_modules/

--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -1,0 +1,64 @@
+# Deployment Guide
+
+## Requirements
+- PHP 8.1 with PDO SQLite, Imagick (optional for faster image conversion)
+- Node.js 18+ for QA tooling and Lighthouse CI
+- Web server (Apache 2.4+ or Nginx 1.20+) with HTTPS enabled
+
+## Build & Asset Pipeline
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Generate responsive image derivatives (WebP/AVIF variants under `public/media/generated/`):
+   ```bash
+   npm run build:images
+   ```
+3. Run quality gates (requires the application to be served locally on `http://localhost:8080`):
+   ```bash
+   npm run audit
+   ```
+   Reports are written to `reports/` (`lighthouse/`, `html-validation.txt`, `schema-validation.json`).
+
+## Environment Variables
+- `ASSET_CDN_URL`: Optional CDN base for static assets.
+- `FEATURE_GENETICS_TEASER`: Set to `0` to hide the Genetik-Rechner CTA on the homepage.
+- `CLOUDFLARE_ZONE_ID` / `CLOUDFLARE_API_TOKEN`: Enable CDN cache purge via `scripts/purge-cache.sh`.
+
+## Web Server Configuration
+### Apache (`public/.htaccess` already included)
+- Long-term caching for static assets (1 year for images, 7 days for CSS/JS).
+- Security headers (`X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`).
+- Rewrites to expose `sitemap.xml` and `robots.txt`.
+- Consider enabling mod_cache or a reverse proxy with micro-caching (30–120s) for HTML.
+
+### Nginx snippet
+```
+location / {
+    try_files $uri /index.php?$query_string;
+}
+
+location ~* \.(css|js)$ {
+    expires 7d;
+    add_header Cache-Control "public, max-age=604800";
+}
+
+location ~* \.(png|jpg|jpeg|gif|webp|avif|svg)$ {
+    expires 365d;
+    add_header Cache-Control "public, max-age=31536000, immutable";
+}
+
+# micro cache for HTML
+proxy_cache ferox_micro;
+proxy_cache_valid 200 60s;
+proxy_cache_use_stale error timeout updating;
+```
+
+## Monitoring & Operations
+- Health endpoint: `GET /index.php?route=healthz` returns JSON status.
+- CDN purge: run `./scripts/purge-cache.sh` after deploy (exports required environment variables).
+- Sitemap: `/sitemap.xml` (rewritten to `sitemap.php`) and `robots.txt` are generated automatically at runtime.
+- Deploy hook should ping search engines with the sitemap URL (e.g. `curl https://www.google.com/ping?sitemap=https://bartagame.eu/sitemap.xml`).
+
+## Database Migrations
+No schema changes in this release. Ensure the SQLite file under `storage/database.sqlite` remains writable by the web server user.

--- a/app/adoption.php
+++ b/app/adoption.php
@@ -1,7 +1,7 @@
 <?php
 function create_listing(PDO $pdo, array $data): void
 {
-    $stmt = $pdo->prepare('INSERT INTO adoption_listings(animal_id, title, species, genetics, price, description, image_path, status, contact_email) VALUES (:animal_id, :title, :species, :genetics, :price, :description, :image_path, :status, :contact_email)');
+    $stmt = $pdo->prepare('INSERT INTO adoption_listings(animal_id, title, species, genetics, price, description, image_path, sex, status, contact_email) VALUES (:animal_id, :title, :species, :genetics, :price, :description, :image_path, :sex, :status, :contact_email)');
     $stmt->execute([
         'animal_id' => $data['animal_id'] ?: null,
         'title' => $data['title'],
@@ -10,6 +10,7 @@ function create_listing(PDO $pdo, array $data): void
         'price' => $data['price'] ?? null,
         'description' => $data['description'] ?? null,
         'image_path' => $data['image_path'] ?? null,
+        'sex' => $data['sex'] ?? 'unknown',
         'status' => $data['status'] ?? 'available',
         'contact_email' => $data['contact_email'] ?? null,
     ]);
@@ -17,7 +18,7 @@ function create_listing(PDO $pdo, array $data): void
 
 function update_listing(PDO $pdo, int $id, array $data): void
 {
-    $stmt = $pdo->prepare('UPDATE adoption_listings SET animal_id = :animal_id, title = :title, species = :species, genetics = :genetics, price = :price, description = :description, image_path = :image_path, status = :status, contact_email = :contact_email WHERE id = :id');
+    $stmt = $pdo->prepare('UPDATE adoption_listings SET animal_id = :animal_id, title = :title, species = :species, genetics = :genetics, price = :price, description = :description, image_path = :image_path, sex = :sex, status = :status, contact_email = :contact_email WHERE id = :id');
     $stmt->execute([
         'animal_id' => $data['animal_id'] ?: null,
         'title' => $data['title'],
@@ -26,6 +27,7 @@ function update_listing(PDO $pdo, int $id, array $data): void
         'price' => $data['price'] ?? null,
         'description' => $data['description'] ?? null,
         'image_path' => $data['image_path'] ?? null,
+        'sex' => $data['sex'] ?? 'unknown',
         'status' => $data['status'] ?? 'available',
         'contact_email' => $data['contact_email'] ?? null,
         'id' => $id,

--- a/app/animals.php
+++ b/app/animals.php
@@ -1,7 +1,7 @@
 <?php
 function create_animal(PDO $pdo, array $data): void
 {
-    $stmt = $pdo->prepare('INSERT INTO animals(name, species, age, genetics, origin, special_notes, description, image_path, owner_id, is_private, is_showcased) VALUES (:name, :species, :age, :genetics, :origin, :special_notes, :description, :image_path, :owner_id, :is_private, :is_showcased)');
+    $stmt = $pdo->prepare('INSERT INTO animals(name, species, age, genetics, origin, special_notes, description, image_path, owner_id, is_private, is_showcased, is_piebald) VALUES (:name, :species, :age, :genetics, :origin, :special_notes, :description, :image_path, :owner_id, :is_private, :is_showcased, :is_piebald)');
     $stmt->execute([
         'name' => $data['name'],
         'species' => $data['species'],
@@ -14,12 +14,13 @@ function create_animal(PDO $pdo, array $data): void
         'owner_id' => $data['owner_id'] ?: null,
         'is_private' => !empty($data['is_private']) ? 1 : 0,
         'is_showcased' => !empty($data['is_showcased']) ? 1 : 0,
+        'is_piebald' => !empty($data['is_piebald']) ? 1 : 0,
     ]);
 }
 
 function update_animal(PDO $pdo, int $id, array $data): void
 {
-    $stmt = $pdo->prepare('UPDATE animals SET name = :name, species = :species, age = :age, genetics = :genetics, origin = :origin, special_notes = :special_notes, description = :description, image_path = :image_path, owner_id = :owner_id, is_private = :is_private, is_showcased = :is_showcased WHERE id = :id');
+    $stmt = $pdo->prepare('UPDATE animals SET name = :name, species = :species, age = :age, genetics = :genetics, origin = :origin, special_notes = :special_notes, description = :description, image_path = :image_path, owner_id = :owner_id, is_private = :is_private, is_showcased = :is_showcased, is_piebald = :is_piebald WHERE id = :id');
     $stmt->execute([
         'name' => $data['name'],
         'species' => $data['species'],
@@ -32,6 +33,7 @@ function update_animal(PDO $pdo, int $id, array $data): void
         'owner_id' => $data['owner_id'] ?: null,
         'is_private' => !empty($data['is_private']) ? 1 : 0,
         'is_showcased' => !empty($data['is_showcased']) ? 1 : 0,
+        'is_piebald' => !empty($data['is_piebald']) ? 1 : 0,
         'id' => $id
     ]);
 }

--- a/app/animals.php
+++ b/app/animals.php
@@ -1,11 +1,12 @@
 <?php
 function create_animal(PDO $pdo, array $data): void
 {
-    $stmt = $pdo->prepare('INSERT INTO animals(name, species, age, genetics, origin, special_notes, description, image_path, owner_id, is_private, is_showcased, is_piebald) VALUES (:name, :species, :age, :genetics, :origin, :special_notes, :description, :image_path, :owner_id, :is_private, :is_showcased, :is_piebald)');
+    $stmt = $pdo->prepare('INSERT INTO animals(name, species, age, sex, genetics, origin, special_notes, description, image_path, owner_id, is_private, is_showcased, is_piebald) VALUES (:name, :species, :age, :sex, :genetics, :origin, :special_notes, :description, :image_path, :owner_id, :is_private, :is_showcased, :is_piebald)');
     $stmt->execute([
         'name' => $data['name'],
         'species' => $data['species'],
         'age' => $data['age'] ?? null,
+        'sex' => $data['sex'] ?? 'unknown',
         'genetics' => $data['genetics'] ?? null,
         'origin' => $data['origin'] ?? null,
         'special_notes' => $data['special_notes'] ?? null,
@@ -20,11 +21,12 @@ function create_animal(PDO $pdo, array $data): void
 
 function update_animal(PDO $pdo, int $id, array $data): void
 {
-    $stmt = $pdo->prepare('UPDATE animals SET name = :name, species = :species, age = :age, genetics = :genetics, origin = :origin, special_notes = :special_notes, description = :description, image_path = :image_path, owner_id = :owner_id, is_private = :is_private, is_showcased = :is_showcased, is_piebald = :is_piebald WHERE id = :id');
+    $stmt = $pdo->prepare('UPDATE animals SET name = :name, species = :species, age = :age, sex = :sex, genetics = :genetics, origin = :origin, special_notes = :special_notes, description = :description, image_path = :image_path, owner_id = :owner_id, is_private = :is_private, is_showcased = :is_showcased, is_piebald = :is_piebald WHERE id = :id');
     $stmt->execute([
         'name' => $data['name'],
         'species' => $data['species'],
         'age' => $data['age'] ?? null,
+        'sex' => $data['sex'] ?? 'unknown',
         'genetics' => $data['genetics'] ?? null,
         'origin' => $data['origin'] ?? null,
         'special_notes' => $data['special_notes'] ?? null,

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/config.php';
+require_once __DIR__ . '/site.php';
 require_once __DIR__ . '/database.php';
 require_once __DIR__ . '/helpers.php';
 require_once __DIR__ . '/auth.php';

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -7,8 +7,15 @@ require_once __DIR__ . '/settings.php';
 require_once __DIR__ . '/animals.php';
 require_once __DIR__ . '/adoption.php';
 require_once __DIR__ . '/users.php';
+require_once __DIR__ . '/pages.php';
+require_once __DIR__ . '/news.php';
+require_once __DIR__ . '/breeding.php';
+require_once __DIR__ . '/careguide.php';
+require_once __DIR__ . '/genetics.php';
 
 $pdo = get_database_connection();
 initialize_database($pdo);
 ensure_default_admin($pdo);
 ensure_default_settings($pdo);
+ensure_default_care_articles($pdo);
+ensure_default_genetics($pdo);

--- a/app/breeding.php
+++ b/app/breeding.php
@@ -1,0 +1,82 @@
+<?php
+function create_breeding_plan(PDO $pdo, array $data): int
+{
+    $stmt = $pdo->prepare('INSERT INTO breeding_plans(title, season, notes, expected_genetics, incubation_notes) VALUES (:title, :season, :notes, :expected_genetics, :incubation_notes)');
+    $stmt->execute([
+        'title' => $data['title'],
+        'season' => $data['season'] ?? null,
+        'notes' => $data['notes'] ?? null,
+        'expected_genetics' => $data['expected_genetics'] ?? null,
+        'incubation_notes' => $data['incubation_notes'] ?? null,
+    ]);
+    return (int)$pdo->lastInsertId();
+}
+
+function update_breeding_plan(PDO $pdo, int $id, array $data): void
+{
+    $stmt = $pdo->prepare('UPDATE breeding_plans SET title = :title, season = :season, notes = :notes, expected_genetics = :expected_genetics, incubation_notes = :incubation_notes WHERE id = :id');
+    $stmt->execute([
+        'title' => $data['title'],
+        'season' => $data['season'] ?? null,
+        'notes' => $data['notes'] ?? null,
+        'expected_genetics' => $data['expected_genetics'] ?? null,
+        'incubation_notes' => $data['incubation_notes'] ?? null,
+        'id' => $id,
+    ]);
+}
+
+function delete_breeding_plan(PDO $pdo, int $id): void
+{
+    $stmt = $pdo->prepare('DELETE FROM breeding_plans WHERE id = :id');
+    $stmt->execute(['id' => $id]);
+}
+
+function get_breeding_plan(PDO $pdo, int $id): ?array
+{
+    $stmt = $pdo->prepare('SELECT * FROM breeding_plans WHERE id = :id');
+    $stmt->execute(['id' => $id]);
+    $plan = $stmt->fetch();
+    if (!$plan) {
+        return null;
+    }
+    $plan['parents'] = get_breeding_parents($pdo, $id);
+    return $plan;
+}
+
+function get_breeding_plans(PDO $pdo): array
+{
+    $plans = $pdo->query('SELECT * FROM breeding_plans ORDER BY created_at DESC')->fetchAll();
+    foreach ($plans as &$plan) {
+        $plan['parents'] = get_breeding_parents($pdo, (int)$plan['id']);
+    }
+    return $plans;
+}
+
+function add_breeding_parent(PDO $pdo, array $data): void
+{
+    $stmt = $pdo->prepare('INSERT INTO breeding_plan_parents(plan_id, parent_type, animal_id, name, sex, species, genetics, notes) VALUES (:plan_id, :parent_type, :animal_id, :name, :sex, :species, :genetics, :notes)');
+    $stmt->execute([
+        'plan_id' => $data['plan_id'],
+        'parent_type' => $data['parent_type'],
+        'animal_id' => $data['parent_type'] === 'animal' ? ($data['animal_id'] ?: null) : null,
+        'name' => $data['name'] ?? null,
+        'sex' => $data['sex'] ?? null,
+        'species' => $data['species'] ?? null,
+        'genetics' => $data['genetics'] ?? null,
+        'notes' => $data['notes'] ?? null,
+    ]);
+}
+
+function delete_breeding_parent(PDO $pdo, int $id): void
+{
+    $stmt = $pdo->prepare('DELETE FROM breeding_plan_parents WHERE id = :id');
+    $stmt->execute(['id' => $id]);
+}
+
+function get_breeding_parents(PDO $pdo, int $planId): array
+{
+    $stmt = $pdo->prepare('SELECT breeding_plan_parents.*, animals.name AS animal_name, animals.species AS animal_species, animals.genetics AS animal_genetics FROM breeding_plan_parents LEFT JOIN animals ON animals.id = breeding_plan_parents.animal_id WHERE plan_id = :plan ORDER BY breeding_plan_parents.id ASC');
+    $stmt->execute(['plan' => $planId]);
+    return $stmt->fetchAll();
+}
+

--- a/app/careguide.php
+++ b/app/careguide.php
@@ -1,0 +1,255 @@
+<?php
+function create_care_article(PDO $pdo, array $data): int
+{
+    $slug = $data['slug'] ?: slugify($data['title']);
+    $slug = ensure_unique_slug($pdo, 'care_articles', $slug);
+    $stmt = $pdo->prepare('INSERT INTO care_articles(title, slug, summary, content, is_published) VALUES (:title, :slug, :summary, :content, :is_published)');
+    $stmt->execute([
+        'title' => $data['title'],
+        'slug' => $slug,
+        'summary' => $data['summary'] ?? null,
+        'content' => $data['content'],
+        'is_published' => !empty($data['is_published']) ? 1 : 0,
+    ]);
+    return (int)$pdo->lastInsertId();
+}
+
+function update_care_article(PDO $pdo, int $id, array $data): void
+{
+    $slug = $data['slug'] ?: slugify($data['title']);
+    $slug = ensure_unique_slug($pdo, 'care_articles', $slug, $id);
+    $stmt = $pdo->prepare('UPDATE care_articles SET title = :title, slug = :slug, summary = :summary, content = :content, is_published = :is_published, updated_at = CURRENT_TIMESTAMP WHERE id = :id');
+    $stmt->execute([
+        'title' => $data['title'],
+        'slug' => $slug,
+        'summary' => $data['summary'] ?? null,
+        'content' => $data['content'],
+        'is_published' => !empty($data['is_published']) ? 1 : 0,
+        'id' => $id,
+    ]);
+}
+
+function delete_care_article(PDO $pdo, int $id): void
+{
+    $stmt = $pdo->prepare('DELETE FROM care_articles WHERE id = :id');
+    $stmt->execute(['id' => $id]);
+}
+
+function get_care_articles(PDO $pdo): array
+{
+    return $pdo->query('SELECT * FROM care_articles ORDER BY title ASC')->fetchAll();
+}
+
+function get_published_care_articles(PDO $pdo): array
+{
+    return $pdo->query('SELECT * FROM care_articles WHERE is_published = 1 ORDER BY title ASC')->fetchAll();
+}
+
+function get_care_article(PDO $pdo, int $id): ?array
+{
+    $stmt = $pdo->prepare('SELECT * FROM care_articles WHERE id = :id');
+    $stmt->execute(['id' => $id]);
+    $article = $stmt->fetch();
+    return $article ?: null;
+}
+
+function get_care_article_by_slug(PDO $pdo, string $slug): ?array
+{
+    $stmt = $pdo->prepare('SELECT * FROM care_articles WHERE slug = :slug');
+    $stmt->execute(['slug' => $slug]);
+    $article = $stmt->fetch();
+    return $article ?: null;
+}
+
+function ensure_default_care_articles(PDO $pdo): void
+{
+    $defaults = [
+        'pogona-vitticeps' => [
+            'title' => 'Pogona vitticeps – umfassender Pflegeleitfaden',
+            'summary' => 'Kompletter Praxisleitfaden für die artgerechte Haltung, Ernährung, Technik und Gesundheitsvorsorge von Bartagamen (Pogona vitticeps).',
+            'content' => <<<HTML
+<h2>Steckbrief</h2>
+<p><strong>Wissenschaftlicher Name:</strong> <em>Pogona vitticeps</em><br>
+<strong>Umgangssprache:</strong> Bartagame, Inland-Bearded Dragon<br>
+<strong>Herkunft:</strong> Halbwüsten und Savannen Zentralaustraliens<br>
+<strong>Lebenserwartung:</strong> 10–14 Jahre bei konsequenter Pflege</p>
+
+<h2>Terrarium und Technik</h2>
+<p>Für adulte Tiere wird ein Terrarium von mindestens <strong>150 × 80 × 80&nbsp;cm</strong> empfohlen. Jungtiere starten in 100 × 60 × 60&nbsp;cm, damit sie Futter sicher finden. Arbeiten Sie mit Rückwandmodulen, erhöhten Sonnenplätzen und mehreren Höhlen.</p>
+<ul>
+    <li><strong>Substrat:</strong> Grabfähiges Lehm-Sand-Gemisch (60&nbsp;% Spielsand, 40&nbsp;% Lehm), teilweise mit Steinplatten kombiniert.</li>
+    <li><strong>Klima:</strong> Tagesluftfeuchte 30–40&nbsp;%, nachts bis 50&nbsp;% durch gezieltes Sprühen.</li>
+    <li><strong>Struktur:</strong> Astgabeln, Plateaus und Sichtschutz, um thermische Mikroklimata zu schaffen.</li>
+</ul>
+
+<h3>Beleuchtung und Temperatur</h3>
+<table>
+    <thead>
+        <tr><th>Zone</th><th>Temperatur</th><th>Technik</th></tr>
+    </thead>
+    <tbody>
+        <tr><td>Sonnenplatz</td><td>45–50&nbsp;°C</td><td>HQI oder Metalldampflampe (70–100&nbsp;W) plus Halogen-Spot</td></tr>
+        <tr><td>Grundtemperatur</td><td>28–32&nbsp;°C</td><td>Flächige T5-HO Tageslichtröhren (6500&nbsp;K)</td></tr>
+        <tr><td>Kühle Zone</td><td>24–26&nbsp;°C</td><td>Schattenbereiche, Höhlen</td></tr>
+        <tr><td>Nacht</td><td>18–22&nbsp;°C</td><td>keine Zusatzheizung, Raumtemperatur genügt</td></tr>
+    </tbody>
+</table>
+<p><strong>UV-B:</strong> Hochwertige Mischlichtlampe mit Reflektor (z.&nbsp;B. SolarRaptor). Brenndauer 11–12&nbsp;Stunden, Tauschintervalle gemäß Hersteller.</p>
+
+<h2>Fütterung</h2>
+<p>Bartagamen sind omnivor. Der Insektenanteil nimmt mit dem Alter ab:</p>
+<ul>
+    <li><strong>Jungtiere:</strong> 70&nbsp;% Insekten, 30&nbsp;% Grünfutter, tägliche Fütterung.</li>
+    <li><strong>Subadulte:</strong> 50&nbsp;% Insekten, Rest Wildkräuter, drei bis vier Fütterungen pro Woche.</li>
+    <li><strong>Adulte:</strong> 20–30&nbsp;% Insekten, Schwerpunkt auf Wildkräuter- und Blütenmix.</li>
+</ul>
+<p>Calcium ohne D3 bei jeder Insektenfütterung, Kombipräparat zweimal wöchentlich. Insekten stets gut füttern (<em>gut loaden</em>).</p>
+
+<h2>Gesundheitsvorsorge</h2>
+<p>Mindestens jährlich Kotuntersuchung auf Parasiten, Gewichtsprotokoll führen und auf Hinweise einer metabolischen Knochenerkrankung achten (Schwellungen am Kiefer, weicher Panzer). Bei Auffälligkeiten sofort reptilienkundigen Tierarzt konsultieren.</p>
+
+<h2>Winterruhe und Zucht</h2>
+<p>Eine Winterruhe von 8–10 Wochen bei 16&nbsp;°C stabilisiert den Stoffwechsel und ist Voraussetzung für die Zucht. Nach dem Erwärmen Paarungen nur mit gesunden, ausgewachsenen Tieren ansetzen.</p>
+HTML,
+        ],
+        'heterodon-nasicus' => [
+            'title' => 'Heterodon nasicus – Pflegeleitfaden für Hakennasennattern',
+            'summary' => 'Ausführlicher Leitfaden zur Haltung, Ernährung, Winterruhe und Genetikplanung der westlichen Hakennasennatter (Heterodon nasicus).',
+            'content' => <<<HTML
+<h2>Steckbrief</h2>
+<p><strong>Wissenschaftlicher Name:</strong> <em>Heterodon nasicus</em><br>
+<strong>Verbreitung:</strong> Zentrale Prärien Nordamerikas<br>
+<strong>Biotop:</strong> Sandige Steppen, lückige Grasflächen<br>
+<strong>Charakter:</strong> tagaktiv, grabend, stressresistent</p>
+
+<h2>Unterbringung</h2>
+<p>Ein Einzeltier benötigt mindestens <strong>90 × 45 × 45&nbsp;cm</strong>. Für Paare bzw. größere Tiere sind 120&nbsp;cm Länge ideal.</p>
+<ul>
+    <li><strong>Substrat:</strong> Gemisch aus Sand, Pinienhumus und Sphagnum, 8–10&nbsp;cm tief zum Eingraben.</li>
+    <li><strong>Verstecke:</strong> Korkröhren, Halbhöhlen und grabfähige Boxen.</li>
+    <li><strong>Feuchtebox:</strong> Plastikbox mit feuchtem Sphagnum zur Häutung.</li>
+</ul>
+
+<h3>Klima</h3>
+<table>
+    <thead><tr><th>Zone</th><th>Temperatur</th><th>Hinweis</th></tr></thead>
+    <tbody>
+        <tr><td>Sonnenplatz</td><td>33–35&nbsp;°C</td><td>Spotstrahler 35–50&nbsp;W</td></tr>
+        <tr><td>Grundtemperatur</td><td>26–28&nbsp;°C</td><td>Flächenheizung oder Keramikstrahler</td></tr>
+        <tr><td>Nacht</td><td>20–22&nbsp;°C</td><td>leichter Temperaturabfall fördert Aktivität</td></tr>
+    </tbody>
+</table>
+<p>Luftfeuchte tagsüber 40–50&nbsp;%, nachts 60&nbsp;%. Kurzes Sprühen genügt.</p>
+
+<h2>Ernährung</h2>
+<p>Hakennasennattern fressen in Gefangenschaft zuverlässig frostaufgetaute Nager in passenden Größen. Ergänzend sind Geruchsreize durch Duftstreifen (z.&nbsp;B. Amphibien) möglich. Nach der Fütterung drei bis vier Tage Ruhe gewähren.</p>
+
+<h2>Winterruhe</h2>
+<p>Von November bis Januar empfiehlt sich eine Winterruhe bei 10–12&nbsp;°C. Drei Wochen vorher keine Fütterung mehr, Tiere entleeren lassen, dann langsam abkühlen. Nach dem Aufwärmen steigert man das Futterangebot, bevor man Zuchtprojekte startet.</p>
+
+<h2>Genetik und Morphe</h2>
+<p>Die Art weist zahlreiche rezessive und inkomplett dominante Linien auf (Albino, Toffee, Axanthic, Anaconda, Arctic, Hypo). Unser Genetik-Rechner unterstützt die Planung: Markieren Sie visuelle Formen (z.&nbsp;B. „Albino“) sowie Trägerstatus („het Toffee“), um Punnett-Auswertungen für Nachzuchten zu erhalten.</p>
+
+<h2>Gesundheitsmanagement</h2>
+<ul>
+    <li>Regelmäßige Gewichtskontrollen – Abnahmen deuten auf Parasiten oder zu niedrige Temperaturen hin.</li>
+    <li>Achten Sie auf Resthäutungen an der Schwanzspitze, bei Bedarf lauwarmes Bad anbieten.</li>
+    <li>Frisches Wasser täglich, Näpfe mindestens wöchentlich desinfizieren.</li>
+</ul>
+HTML,
+        ],
+        'heloderma-suspectum' => [
+            'title' => 'Heloderma suspectum – Leitfaden Gila-Krustenechse',
+            'summary' => 'Pflegehinweise für Heloderma suspectum mit Fokus auf Sicherheit, Ernährung und klimatische Ansprüche der giftigen Krustenechsen.',
+            'content' => <<<HTML
+<h2>Rechtlicher Hinweis</h2>
+<p><strong>Heloderma</strong>-Arten sind giftig und vielerorts genehmigungspflichtig. Prüfen Sie vor der Anschaffung die lokalen Auflagen (Sachkunde, Anzeige- bzw. Haltegenehmigung).</p>
+
+<h2>Habitat und Gehege</h2>
+<p>Empfohlen wird ein Bodenterrarium von mindestens <strong>200 × 100 × 80&nbsp;cm</strong> mit massiver Sicherung. Doppelte Türen oder Vorraum sind Pflicht.</p>
+<ul>
+    <li><strong>Substrat:</strong> Lehm-Sand-Gemisch, stellenweise mit Kies und großflächigen Steinplatten.</li>
+    <li><strong>Struktur:</strong> schwere Wurzelstücke, Höhlen, trockene und feuchte Rückzugsbereiche.</li>
+    <li><strong>Sicherheit:</strong> Terrarium verriegeln, Arbeitshaken und Schutzbox bereithalten.</li>
+</ul>
+
+<h3>Klima</h3>
+<table>
+    <thead><tr><th>Bereich</th><th>Temperatur</th><th>Feuchte</th></tr></thead>
+    <tbody>
+        <tr><td>Hot Spot</td><td>38–40&nbsp;°C</td><td>trocken</td></tr>
+        <tr><td>Grundbereich</td><td>28–30&nbsp;°C</td><td>40–50&nbsp;%</td></tr>
+        <tr><td>Feuchtversteck</td><td>24–26&nbsp;°C</td><td>70&nbsp;%</td></tr>
+        <tr><td>Nacht</td><td>20–22&nbsp;°C</td><td>leicht erhöht</td></tr>
+    </tbody>
+</table>
+
+<h2>Ernährung</h2>
+<p>Gila-Krustenechsen sind carnivor. Füttern Sie adulte Tiere alle 10–14 Tage mit kleinen Nagern, Küken oder Wachteleiern. Jungtiere erhalten wöchentlich kleinere Portionen. Überfütterung führt zu Fettleibigkeit; ein Jahreszyklus mit reduzierter Winterfütterung ist empfehlenswert.</p>
+
+<h2>Handhabung</h2>
+<p>Handling nur mit Haken und Sicherungsbehälter. Bisse sind schmerzhaft und medizinisch ernstzunehmen. Arbeiten Sie stets zu zweit.</p>
+HTML,
+        ],
+        'heloderma-horridum' => [
+            'title' => 'Heloderma horridum – Leitfaden Mexikanische Krustenechse',
+            'summary' => 'Spezialisierter Leitfaden für Heloderma horridum mit Schwerpunkt auf Mikroklima und saisonaler Pflege.',
+            'content' => <<<HTML
+<h2>Besonderheiten</h2>
+<p><em>Heloderma horridum</em> lebt in semi-ariden Regionen Mexikos und benötigt saisonale Schwankungen. Eine Regenzeit-Phase fördert Wohlbefinden und Fortpflanzung.</p>
+
+<h2>Klima und Saison</h2>
+<ul>
+    <li><strong>Trockenzeit (Oktober–März):</strong> Tag 26–28&nbsp;°C, Nacht 18&nbsp;°C, Luftfeuchte 35–40&nbsp;%, reduziertes Futter.</li>
+    <li><strong>Regenzeit (April–September):</strong> Tag 30–32&nbsp;°C, Nacht 22&nbsp;°C, Luftfeuchte 60–70&nbsp;%, regelmäßige Sprühintervalle.</li>
+</ul>
+
+<h2>Ernährung</h2>
+<p>Das Nahrungsspektrum umfasst Nager, Eizellen, Nestlinge und gelegentlich Insekten. Kalkulieren Sie die Jahresration: Erwachsene benötigen rund 15&nbsp;% ihres Körpergewichts an Futter pro Jahr.</p>
+
+<h2>Zucht</h2>
+<p>Nach der Regenzeit lassen sich Pärchen zusammenführen. Eiablage erfolgt 45–55 Tage nach der Paarung in lockerer Erde. Inkubation bei 29&nbsp;°C und 70&nbsp;% Feuchte dauert 150–180 Tage.</p>
+HTML,
+        ],
+        'heloderma-alvarezi' => [
+            'title' => 'Heloderma alvarezi – Leitfaden Chiapan-Krustenechse',
+            'summary' => 'Pflegeprofil für Heloderma alvarezi mit Fokus auf hohe Luftfeuchte und strukturreiche Terrarien.',
+            'content' => <<<HTML
+<h2>Habitat</h2>
+<p><em>Heloderma alvarezi</em> stammt aus den feuchten Bergregionen Chiapas. Terrarien sollten dicht bepflanzte Bereiche, Kletterstrukturen und mehrere feuchte Rückzugsorte enthalten.</p>
+
+<h2>Klima</h2>
+<table>
+    <thead><tr><th>Tag</th><th>Nacht</th><th>Feuchte</th></tr></thead>
+    <tbody>
+        <tr><td>27–29&nbsp;°C</td><td>20–22&nbsp;°C</td><td>65–75&nbsp;%</td></tr>
+    </tbody>
+</table>
+<p>Nebel- oder Beregnungsanlagen mit Intervallen von 2–3 Minuten morgens und abends stabilisieren die Luftfeuchte.</p>
+
+<h2>Pflegehinweise</h2>
+<ul>
+    <li>Große Wasserschale zum Baden bereitstellen, wöchentlich wechseln.</li>
+    <li>Proteinreiche Ernährung (Nager, Wachteleier), Ergänzung durch Calciumpräparate.</li>
+    <li>Regelmäßige Gesundheitschecks inkl. Blutprofil empfehlenswert.</li>
+</ul>
+HTML,
+        ],
+    ];
+
+    foreach ($defaults as $slug => $data) {
+        $stmt = $pdo->prepare('SELECT COUNT(*) FROM care_articles WHERE slug = :slug');
+        $stmt->execute(['slug' => $slug]);
+        if ($stmt->fetchColumn() > 0) {
+            continue;
+        }
+        create_care_article($pdo, [
+            'title' => $data['title'],
+            'slug' => $slug,
+            'summary' => $data['summary'],
+            'content' => $data['content'],
+            'is_published' => 1,
+        ]);
+    }
+}
+

--- a/app/database.php
+++ b/app/database.php
@@ -14,6 +14,7 @@ function get_database_connection(): PDO
     $pdo = new PDO('sqlite:' . DATA_PATH);
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
     $pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+    $pdo->exec('PRAGMA foreign_keys = ON');
     return $pdo;
 }
 
@@ -48,9 +49,22 @@ function initialize_database(PDO $pdo): void
         owner_id INTEGER,
         is_private INTEGER NOT NULL DEFAULT 0,
         is_showcased INTEGER NOT NULL DEFAULT 0,
+        is_piebald INTEGER NOT NULL DEFAULT 0,
         created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
         FOREIGN KEY(owner_id) REFERENCES users(id)
     )');
+
+    $animalColumns = $pdo->query('PRAGMA table_info(animals)')->fetchAll();
+    $hasPiebald = false;
+    foreach ($animalColumns as $column) {
+        if (($column['name'] ?? '') === 'is_piebald') {
+            $hasPiebald = true;
+            break;
+        }
+    }
+    if (!$hasPiebald) {
+        $pdo->exec('ALTER TABLE animals ADD COLUMN is_piebald INTEGER NOT NULL DEFAULT 0');
+    }
 
     $pdo->exec('CREATE TABLE IF NOT EXISTS adoption_listings (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -76,5 +90,106 @@ function initialize_database(PDO $pdo): void
         message TEXT NOT NULL,
         created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
         FOREIGN KEY(listing_id) REFERENCES adoption_listings(id)
+    )');
+
+    $pdo->exec('CREATE TABLE IF NOT EXISTS pages (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        title TEXT NOT NULL,
+        slug TEXT NOT NULL UNIQUE,
+        content TEXT NOT NULL,
+        is_published INTEGER NOT NULL DEFAULT 0,
+        show_in_menu INTEGER NOT NULL DEFAULT 0,
+        parent_id INTEGER,
+        menu_order INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )');
+
+    $pageColumns = $pdo->query('PRAGMA table_info(pages)')->fetchAll();
+    $pageColumnNames = array_column($pageColumns, 'name');
+    if (!in_array('show_in_menu', $pageColumnNames, true)) {
+        $pdo->exec('ALTER TABLE pages ADD COLUMN show_in_menu INTEGER NOT NULL DEFAULT 0');
+    }
+    if (!in_array('parent_id', $pageColumnNames, true)) {
+        $pdo->exec('ALTER TABLE pages ADD COLUMN parent_id INTEGER');
+    }
+    if (!in_array('menu_order', $pageColumnNames, true)) {
+        $pdo->exec('ALTER TABLE pages ADD COLUMN menu_order INTEGER NOT NULL DEFAULT 0');
+    }
+
+    $pdo->exec('CREATE TABLE IF NOT EXISTS news_posts (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        title TEXT NOT NULL,
+        slug TEXT NOT NULL UNIQUE,
+        excerpt TEXT,
+        content TEXT NOT NULL,
+        is_published INTEGER NOT NULL DEFAULT 0,
+        published_at TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )');
+
+    $pdo->exec('CREATE TABLE IF NOT EXISTS breeding_plans (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        title TEXT NOT NULL,
+        season TEXT,
+        notes TEXT,
+        expected_genetics TEXT,
+        incubation_notes TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )');
+
+    $pdo->exec('CREATE TABLE IF NOT EXISTS breeding_plan_parents (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        plan_id INTEGER NOT NULL,
+        parent_type TEXT NOT NULL,
+        animal_id INTEGER,
+        name TEXT,
+        sex TEXT,
+        species TEXT,
+        genetics TEXT,
+        notes TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY(plan_id) REFERENCES breeding_plans(id) ON DELETE CASCADE,
+        FOREIGN KEY(animal_id) REFERENCES animals(id)
+    )');
+
+    $pdo->exec('CREATE TABLE IF NOT EXISTS care_articles (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        title TEXT NOT NULL,
+        slug TEXT NOT NULL UNIQUE,
+        summary TEXT,
+        content TEXT NOT NULL,
+        is_published INTEGER NOT NULL DEFAULT 1,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )');
+
+    $pdo->exec('CREATE TABLE IF NOT EXISTS genetic_species (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        slug TEXT NOT NULL UNIQUE,
+        scientific_name TEXT,
+        description TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )');
+
+    $pdo->exec('CREATE TABLE IF NOT EXISTS genetic_genes (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        species_id INTEGER NOT NULL,
+        name TEXT NOT NULL,
+        slug TEXT NOT NULL,
+        shorthand TEXT,
+        inheritance_mode TEXT NOT NULL,
+        description TEXT,
+        normal_label TEXT,
+        heterozygous_label TEXT,
+        homozygous_label TEXT,
+        display_order INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY(species_id) REFERENCES genetic_species(id) ON DELETE CASCADE,
+        UNIQUE(species_id, slug)
     )');
 }

--- a/app/database.php
+++ b/app/database.php
@@ -41,6 +41,7 @@ function initialize_database(PDO $pdo): void
         name TEXT NOT NULL,
         species TEXT NOT NULL,
         age TEXT,
+        sex TEXT,
         genetics TEXT,
         origin TEXT,
         special_notes TEXT,
@@ -55,14 +56,11 @@ function initialize_database(PDO $pdo): void
     )');
 
     $animalColumns = $pdo->query('PRAGMA table_info(animals)')->fetchAll();
-    $hasPiebald = false;
-    foreach ($animalColumns as $column) {
-        if (($column['name'] ?? '') === 'is_piebald') {
-            $hasPiebald = true;
-            break;
-        }
+    $animalColumnNames = array_column($animalColumns, 'name');
+    if (!in_array('sex', $animalColumnNames, true)) {
+        $pdo->exec('ALTER TABLE animals ADD COLUMN sex TEXT');
     }
-    if (!$hasPiebald) {
+    if (!in_array('is_piebald', $animalColumnNames, true)) {
         $pdo->exec('ALTER TABLE animals ADD COLUMN is_piebald INTEGER NOT NULL DEFAULT 0');
     }
 
@@ -75,11 +73,18 @@ function initialize_database(PDO $pdo): void
         price TEXT,
         description TEXT,
         image_path TEXT,
+        sex TEXT,
         status TEXT NOT NULL DEFAULT "available",
         contact_email TEXT,
         created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
         FOREIGN KEY(animal_id) REFERENCES animals(id)
     )');
+
+    $adoptionColumns = $pdo->query('PRAGMA table_info(adoption_listings)')->fetchAll();
+    $adoptionColumnNames = array_column($adoptionColumns, 'name');
+    if (!in_array('sex', $adoptionColumnNames, true)) {
+        $pdo->exec('ALTER TABLE adoption_listings ADD COLUMN sex TEXT');
+    }
 
     $pdo->exec('CREATE TABLE IF NOT EXISTS adoption_inquiries (
         id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/app/genetics.php
+++ b/app/genetics.php
@@ -1,0 +1,607 @@
+<?php
+
+const GENETIC_INHERITANCE_MODES = ['recessive', 'dominant', 'incomplete_dominant'];
+
+function get_genetic_species(PDO $pdo): array
+{
+    return $pdo->query('SELECT * FROM genetic_species ORDER BY name ASC')->fetchAll();
+}
+
+function get_genetic_species_by_id(PDO $pdo, int $id): ?array
+{
+    $stmt = $pdo->prepare('SELECT * FROM genetic_species WHERE id = :id');
+    $stmt->execute(['id' => $id]);
+    $row = $stmt->fetch();
+    return $row ?: null;
+}
+
+function get_genetic_species_by_slug(PDO $pdo, string $slug): ?array
+{
+    $stmt = $pdo->prepare('SELECT * FROM genetic_species WHERE slug = :slug');
+    $stmt->execute(['slug' => $slug]);
+    $row = $stmt->fetch();
+    return $row ?: null;
+}
+
+function create_genetic_species(PDO $pdo, array $data): int
+{
+    $name = trim($data['name'] ?? '');
+    if ($name === '') {
+        throw new InvalidArgumentException('Species name is required.');
+    }
+
+    $slug = trim($data['slug'] ?? '');
+    if ($slug === '') {
+        $slug = slugify($name);
+    }
+    $slug = ensure_unique_slug($pdo, 'genetic_species', $slug);
+
+    $stmt = $pdo->prepare('INSERT INTO genetic_species(name, slug, scientific_name, description) VALUES (:name, :slug, :scientific_name, :description)');
+    $stmt->execute([
+        'name' => $name,
+        'slug' => $slug,
+        'scientific_name' => trim($data['scientific_name'] ?? '') ?: null,
+        'description' => trim($data['description'] ?? '') ?: null,
+    ]);
+
+    return (int)$pdo->lastInsertId();
+}
+
+function update_genetic_species(PDO $pdo, int $id, array $data): void
+{
+    $name = trim($data['name'] ?? '');
+    if ($name === '') {
+        throw new InvalidArgumentException('Species name is required.');
+    }
+
+    $slug = trim($data['slug'] ?? '');
+    if ($slug === '') {
+        $slug = slugify($name);
+    }
+    $slug = ensure_unique_slug($pdo, 'genetic_species', $slug, $id);
+
+    $stmt = $pdo->prepare('UPDATE genetic_species SET name = :name, slug = :slug, scientific_name = :scientific_name, description = :description, updated_at = CURRENT_TIMESTAMP WHERE id = :id');
+    $stmt->execute([
+        'name' => $name,
+        'slug' => $slug,
+        'scientific_name' => trim($data['scientific_name'] ?? '') ?: null,
+        'description' => trim($data['description'] ?? '') ?: null,
+        'id' => $id,
+    ]);
+}
+
+function delete_genetic_species(PDO $pdo, int $id): void
+{
+    $stmt = $pdo->prepare('DELETE FROM genetic_species WHERE id = :id');
+    $stmt->execute(['id' => $id]);
+}
+
+function get_genetic_genes(PDO $pdo, int $speciesId): array
+{
+    $stmt = $pdo->prepare('SELECT * FROM genetic_genes WHERE species_id = :species ORDER BY display_order ASC, name ASC');
+    $stmt->execute(['species' => $speciesId]);
+    return $stmt->fetchAll();
+}
+
+function get_all_genetic_genes(PDO $pdo): array
+{
+    return $pdo->query('SELECT * FROM genetic_genes')->fetchAll();
+}
+
+function get_genetic_gene(PDO $pdo, int $id): ?array
+{
+    $stmt = $pdo->prepare('SELECT * FROM genetic_genes WHERE id = :id');
+    $stmt->execute(['id' => $id]);
+    $row = $stmt->fetch();
+    return $row ?: null;
+}
+
+function normalize_inheritance_mode(string $mode): string
+{
+    $mode = strtolower(trim($mode));
+    if (!in_array($mode, GENETIC_INHERITANCE_MODES, true)) {
+        return 'recessive';
+    }
+    return $mode;
+}
+
+function ensure_unique_gene_slug(PDO $pdo, int $speciesId, string $slug, ?int $ignoreId = null): string
+{
+    $base = $slug ?: bin2hex(random_bytes(4));
+    $candidate = $base;
+    $counter = 1;
+
+    while (true) {
+        $sql = 'SELECT COUNT(*) FROM genetic_genes WHERE species_id = :species AND slug = :slug';
+        $params = ['species' => $speciesId, 'slug' => $candidate];
+        if ($ignoreId !== null) {
+            $sql .= ' AND id != :id';
+            $params['id'] = $ignoreId;
+        }
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute($params);
+        if ((int)$stmt->fetchColumn() === 0) {
+            return $candidate;
+        }
+        $candidate = $base . '-' . (++$counter);
+    }
+}
+
+function create_genetic_gene(PDO $pdo, array $data): int
+{
+    $speciesId = (int)($data['species_id'] ?? 0);
+    if ($speciesId <= 0) {
+        throw new InvalidArgumentException('Species reference missing.');
+    }
+    $name = trim($data['name'] ?? '');
+    if ($name === '') {
+        throw new InvalidArgumentException('Gene name is required.');
+    }
+
+    $slug = trim($data['slug'] ?? '');
+    if ($slug === '') {
+        $slug = slugify($name);
+    }
+    $slug = ensure_unique_gene_slug($pdo, $speciesId, $slug);
+
+    $inheritance = normalize_inheritance_mode($data['inheritance_mode'] ?? '');
+
+    $stmt = $pdo->prepare('INSERT INTO genetic_genes(species_id, name, slug, shorthand, inheritance_mode, description, normal_label, heterozygous_label, homozygous_label, display_order) VALUES (:species_id, :name, :slug, :shorthand, :inheritance_mode, :description, :normal_label, :heterozygous_label, :homozygous_label, :display_order)');
+    $stmt->execute([
+        'species_id' => $speciesId,
+        'name' => $name,
+        'slug' => $slug,
+        'shorthand' => trim($data['shorthand'] ?? '') ?: null,
+        'inheritance_mode' => $inheritance,
+        'description' => trim($data['description'] ?? '') ?: null,
+        'normal_label' => trim($data['normal_label'] ?? '') ?: null,
+        'heterozygous_label' => trim($data['heterozygous_label'] ?? '') ?: null,
+        'homozygous_label' => trim($data['homozygous_label'] ?? '') ?: null,
+        'display_order' => isset($data['display_order']) ? (int)$data['display_order'] : 0,
+    ]);
+
+    return (int)$pdo->lastInsertId();
+}
+
+function update_genetic_gene(PDO $pdo, int $id, array $data): void
+{
+    $gene = get_genetic_gene($pdo, $id);
+    if (!$gene) {
+        throw new InvalidArgumentException('Gene not found.');
+    }
+
+    $name = trim($data['name'] ?? '');
+    if ($name === '') {
+        throw new InvalidArgumentException('Gene name is required.');
+    }
+
+    $slug = trim($data['slug'] ?? '');
+    if ($slug === '') {
+        $slug = slugify($name);
+    }
+    $slug = ensure_unique_gene_slug($pdo, (int)$gene['species_id'], $slug, $id);
+
+    $inheritance = normalize_inheritance_mode($data['inheritance_mode'] ?? $gene['inheritance_mode']);
+
+    $stmt = $pdo->prepare('UPDATE genetic_genes SET name = :name, slug = :slug, shorthand = :shorthand, inheritance_mode = :inheritance_mode, description = :description, normal_label = :normal_label, heterozygous_label = :heterozygous_label, homozygous_label = :homozygous_label, display_order = :display_order, updated_at = CURRENT_TIMESTAMP WHERE id = :id');
+    $stmt->execute([
+        'name' => $name,
+        'slug' => $slug,
+        'shorthand' => trim($data['shorthand'] ?? '') ?: null,
+        'inheritance_mode' => $inheritance,
+        'description' => trim($data['description'] ?? '') ?: null,
+        'normal_label' => trim($data['normal_label'] ?? '') ?: null,
+        'heterozygous_label' => trim($data['heterozygous_label'] ?? '') ?: null,
+        'homozygous_label' => trim($data['homozygous_label'] ?? '') ?: null,
+        'display_order' => isset($data['display_order']) ? (int)$data['display_order'] : (int)$gene['display_order'],
+        'id' => $id,
+    ]);
+}
+
+function delete_genetic_gene(PDO $pdo, int $id): void
+{
+    $stmt = $pdo->prepare('DELETE FROM genetic_genes WHERE id = :id');
+    $stmt->execute(['id' => $id]);
+}
+
+function gene_state_to_alleles(string $state): array
+{
+    return match ($state) {
+        'homozygous' => [1, 1],
+        'heterozygous' => [1, 0],
+        default => [0, 0],
+    };
+}
+
+function allele_sum_to_state(int $sum): string
+{
+    return match ($sum) {
+        2 => 'homozygous',
+        1 => 'heterozygous',
+        default => 'normal',
+    };
+}
+
+function sanitize_gene_state(?string $state): string
+{
+    $state = strtolower((string)$state);
+    return match ($state) {
+        'homozygous', 'super' => 'homozygous',
+        'heterozygous', 'het' => 'heterozygous',
+        default => 'normal',
+    };
+}
+
+function gene_state_label(array $gene, string $state): string
+{
+    $inheritance = $gene['inheritance_mode'];
+    $name = $gene['name'];
+
+    $normalDefault = $gene['normal_label'] ?: 'Wildtyp';
+    $heteroDefault = $gene['heterozygous_label'];
+    $homoDefault = $gene['homozygous_label'];
+
+    if (!$heteroDefault) {
+        if ($inheritance === 'recessive') {
+            $heteroDefault = 'het ' . $name;
+        } else {
+            $heteroDefault = $name;
+        }
+    }
+    if (!$homoDefault) {
+        if ($inheritance === 'recessive') {
+            $homoDefault = $name;
+        } elseif ($inheritance === 'dominant') {
+            $homoDefault = $name . ' (Super)';
+        } else {
+            $homoDefault = 'Super ' . $name;
+        }
+    }
+
+    return match ($state) {
+        'heterozygous' => $heteroDefault,
+        'homozygous' => $homoDefault,
+        default => $normalDefault,
+    };
+}
+
+function gene_state_is_visual(array $gene, string $state): bool
+{
+    return match ($gene['inheritance_mode']) {
+        'recessive' => $state === 'homozygous',
+        'dominant', 'incomplete_dominant' => in_array($state, ['heterozygous', 'homozygous'], true),
+        default => false,
+    };
+}
+
+function gene_state_is_carrier(array $gene, string $state): bool
+{
+    if ($gene['inheritance_mode'] === 'recessive' && $state === 'heterozygous') {
+        return true;
+    }
+    return false;
+}
+
+function genetic_gcd(int $a, int $b): int
+{
+    $a = abs($a);
+    $b = abs($b);
+    if ($a === 0) {
+        return $b === 0 ? 1 : $b;
+    }
+    if ($b === 0) {
+        return $a;
+    }
+    while ($b !== 0) {
+        $temp = $b;
+        $b = $a % $b;
+        $a = $temp;
+    }
+    return $a === 0 ? 1 : $a;
+}
+
+function probability_to_fraction_components(float $probability, int $maxDenominator = 1024): array
+{
+    $probability = max(0.0, min(1.0, $probability));
+    $denominator = 1;
+    $epsilon = 1e-6;
+
+    while ($denominator < $maxDenominator) {
+        $scaled = $probability * $denominator;
+        if (abs(round($scaled) - $scaled) < $epsilon) {
+            break;
+        }
+        $denominator *= 2;
+    }
+
+    $numerator = (int)round($probability * $denominator);
+    if ($numerator === 0 && $probability > 0) {
+        $numerator = 1;
+    }
+
+    $gcd = genetic_gcd($numerator, $denominator);
+
+    return [
+        'numerator' => (int)max(0, $numerator / $gcd),
+        'denominator' => (int)max(1, $denominator / $gcd),
+        'percentage' => $probability * 100,
+    ];
+}
+
+function calculate_gene_distribution(array $gene, string $parentOneState, string $parentTwoState): array
+{
+    $allelesOne = gene_state_to_alleles($parentOneState);
+    $allelesTwo = gene_state_to_alleles($parentTwoState);
+
+    $distribution = [];
+    $total = 0;
+    foreach ($allelesOne as $alleleOne) {
+        foreach ($allelesTwo as $alleleTwo) {
+            $state = allele_sum_to_state($alleleOne + $alleleTwo);
+            $distribution[$state] = ($distribution[$state] ?? 0) + 1;
+            $total++;
+        }
+    }
+
+    foreach ($distribution as $state => $count) {
+        $distribution[$state] = $count / $total;
+    }
+
+    ksort($distribution);
+
+    $states = [];
+    foreach ($distribution as $state => $probability) {
+        $states[] = [
+            'state' => $state,
+            'probability' => $probability,
+            'label' => gene_state_label($gene, $state),
+            'is_visual' => gene_state_is_visual($gene, $state),
+            'is_carrier' => gene_state_is_carrier($gene, $state),
+        ];
+    }
+
+    usort($states, static function ($a, $b) {
+        return $b['probability'] <=> $a['probability'];
+    });
+
+    return $states;
+}
+
+function calculate_genetic_outcomes(array $genes, array $parentOneSelections, array $parentTwoSelections): ?array
+{
+    $geneResults = [];
+
+    foreach ($genes as $gene) {
+        $geneId = (int)$gene['id'];
+        $stateOne = sanitize_gene_state($parentOneSelections[$geneId] ?? null);
+        $stateTwo = sanitize_gene_state($parentTwoSelections[$geneId] ?? null);
+
+        if ($stateOne === 'normal' && $stateTwo === 'normal') {
+            continue;
+        }
+
+        $states = calculate_gene_distribution($gene, $stateOne, $stateTwo);
+        $geneResults[$geneId] = [
+            'gene' => $gene,
+            'states' => $states,
+            'parent_states' => [
+                'parent_one' => $stateOne,
+                'parent_two' => $stateTwo,
+            ],
+        ];
+    }
+
+    if (empty($geneResults)) {
+        return null;
+    }
+
+    $combined = [
+        [
+            'probability' => 1.0,
+            'states' => [],
+            'labels' => [],
+            'visual_traits' => [],
+            'carrier_traits' => [],
+        ],
+    ];
+
+    foreach ($geneResults as $geneId => $geneResult) {
+        $geneStates = $geneResult['states'];
+        $nextCombined = [];
+        foreach ($combined as $entry) {
+            foreach ($geneStates as $stateInfo) {
+                $newStates = $entry['states'];
+                $newStates[$geneId] = $stateInfo['state'];
+
+                $newLabels = $entry['labels'];
+                $newLabels[$geneId] = $stateInfo['label'];
+
+                $visual = $entry['visual_traits'];
+                $carriers = $entry['carrier_traits'];
+
+                if ($stateInfo['is_visual']) {
+                    $visual[$geneId] = $stateInfo['label'];
+                } elseif ($stateInfo['is_carrier']) {
+                    $carriers[$geneId] = $stateInfo['label'];
+                }
+
+                $nextCombined[] = [
+                    'probability' => $entry['probability'] * $stateInfo['probability'],
+                    'states' => $newStates,
+                    'labels' => $newLabels,
+                    'visual_traits' => $visual,
+                    'carrier_traits' => $carriers,
+                ];
+            }
+        }
+        $combined = $nextCombined;
+    }
+
+    $normalized = [];
+    foreach ($combined as $entry) {
+        $key = json_encode($entry['states']);
+        if (!isset($normalized[$key])) {
+            $normalized[$key] = $entry;
+        } else {
+            $normalized[$key]['probability'] += $entry['probability'];
+        }
+    }
+
+    $combinedResults = [];
+    foreach ($normalized as $entry) {
+        $phenotypeParts = [];
+        if (!empty($entry['visual_traits'])) {
+            $phenotypeParts[] = implode(', ', $entry['visual_traits']);
+        }
+        if (!empty($entry['carrier_traits'])) {
+            $phenotypeParts[] = 'Träger: ' . implode(', ', $entry['carrier_traits']);
+        }
+        if (empty($phenotypeParts)) {
+            $phenotype = 'Wildtyp';
+        } else {
+            $phenotype = implode(' • ', $phenotypeParts);
+        }
+        $entry['phenotype'] = $phenotype;
+        $combinedResults[] = $entry;
+    }
+
+    usort($combinedResults, static function ($a, $b) {
+        return $b['probability'] <=> $a['probability'];
+    });
+
+    return [
+        'genes' => $geneResults,
+        'combined' => $combinedResults,
+    ];
+}
+
+function ensure_default_genetics(PDO $pdo): void
+{
+    $existing = get_genetic_species_by_slug($pdo, 'heterodon-nasicus');
+    $defaultDescription = 'Die westliche Hakennasennatter (<em>Heterodon nasicus</em>) besticht durch eine enorme Bandbreite an rezessiven und inkomplett dominanten Linien. Die hinterlegten Gene dienen als fundierte Ausgangsbasis für Punnett-Berechnungen und Zuchtplanung.';
+    if ($existing) {
+        $speciesId = (int)$existing['id'];
+        $currentDescription = trim((string)($existing['description'] ?? ''));
+        if ($currentDescription === 'Western Hognoses (Heterodon nasicus) zeigen eine Vielzahl an rezessiven und inkomplett dominanten Morphen. Die Beispielkonfiguration liefert Startwerte für einen schnellen Einstieg in die Zuchtplanung.' || $currentDescription === '') {
+            update_genetic_species($pdo, $speciesId, [
+                'name' => $existing['name'],
+                'slug' => $existing['slug'],
+                'scientific_name' => $existing['scientific_name'],
+                'description' => $defaultDescription,
+            ]);
+        }
+    } else {
+        $speciesId = create_genetic_species($pdo, [
+            'name' => 'Heterodon nasicus',
+            'slug' => 'heterodon-nasicus',
+            'scientific_name' => 'Heterodon nasicus',
+            'description' => $defaultDescription,
+        ]);
+    }
+
+    $sampleGenes = [
+        [
+            'name' => 'Albino',
+            'slug' => 'albino',
+            'inheritance_mode' => 'recessive',
+            'description' => 'Amelanistischer Farbschlag, der einen kräftigen Gelbton mit rosa Akzenten zeigt. Nur homozygote Tiere sind visuell.',
+            'normal_label' => 'Normal',
+            'heterozygous_label' => 'het Albino',
+            'homozygous_label' => 'Albino',
+            'display_order' => 1,
+        ],
+        [
+            'name' => 'Axanthic',
+            'slug' => 'axanthic',
+            'inheritance_mode' => 'recessive',
+            'description' => 'Reduziert gelbe Pigmente für einen grauen Grundton. Als heterozygotes Tier lediglich Träger.',
+            'normal_label' => 'Normal',
+            'heterozygous_label' => 'het Axanthic',
+            'homozygous_label' => 'Axanthic',
+            'display_order' => 2,
+        ],
+        [
+            'name' => 'Toffee',
+            'slug' => 'toffee',
+            'inheritance_mode' => 'recessive',
+            'description' => 'Variante mit karamellfarbener Grundfarbe. Wird in Kombinationen oft mit Albino oder Toffeeglow genutzt.',
+            'normal_label' => 'Normal',
+            'heterozygous_label' => 'het Toffee',
+            'homozygous_label' => 'Toffee',
+            'display_order' => 3,
+        ],
+        [
+            'name' => 'Anaconda',
+            'slug' => 'anaconda',
+            'inheritance_mode' => 'incomplete_dominant',
+            'description' => 'Inkomplett dominanter Zeichnungsmorph mit verengten Sattelflecken; Superform als Superconda nahezu patternless.',
+            'normal_label' => 'Wildtyp',
+            'heterozygous_label' => 'Anaconda',
+            'homozygous_label' => 'Super Anaconda',
+            'display_order' => 4,
+        ],
+        [
+            'name' => 'Hypo',
+            'slug' => 'hypo',
+            'inheritance_mode' => 'recessive',
+            'description' => 'Reduzierter Schwarzanteil sorgt für hellere Grundfarbe und klarere Zeichnung.',
+            'normal_label' => 'Normal',
+            'heterozygous_label' => 'het Hypo',
+            'homozygous_label' => 'Hypo',
+            'display_order' => 5,
+        ],
+        [
+            'name' => 'Toffeebelly',
+            'slug' => 'toffeebelly',
+            'inheritance_mode' => 'incomplete_dominant',
+            'description' => 'Belly-Pattern-Variante mit karamellfarbenem Bauch. Superform verstärkt Kontrast und reduziert Zeichnung.',
+            'normal_label' => 'Wildtyp',
+            'heterozygous_label' => 'Toffeebelly',
+            'homozygous_label' => 'Super Toffeebelly',
+            'display_order' => 6,
+        ],
+        [
+            'name' => 'Arctic',
+            'slug' => 'arctic',
+            'inheritance_mode' => 'incomplete_dominant',
+            'description' => 'Erhöht Kontrast und reduziert schwarze Pigmente; Super Arctic liefert stark aufgehellte Tiere.',
+            'normal_label' => 'Wildtyp',
+            'heterozygous_label' => 'Arctic',
+            'homozygous_label' => 'Super Arctic',
+            'display_order' => 7,
+        ],
+        [
+            'name' => 'Sable',
+            'slug' => 'sable',
+            'inheritance_mode' => 'recessive',
+            'description' => 'Dunkler Morphpartner mit kräftiger Zeichnung. Rezessiv vererbter Kontrastverstärker.',
+            'normal_label' => 'Normal',
+            'heterozygous_label' => 'het Sable',
+            'homozygous_label' => 'Sable',
+            'display_order' => 8,
+        ],
+        [
+            'name' => 'Lavender',
+            'slug' => 'lavender',
+            'inheritance_mode' => 'recessive',
+            'description' => 'Pastellfarbene Variante mit violettem Grundton, beliebt in Kombination mit Albino und Arctic.',
+            'normal_label' => 'Normal',
+            'heterozygous_label' => 'het Lavender',
+            'homozygous_label' => 'Lavender',
+            'display_order' => 9,
+        ],
+    ];
+
+    foreach ($sampleGenes as $sample) {
+        $stmt = $pdo->prepare('SELECT id FROM genetic_genes WHERE species_id = :species AND slug = :slug');
+        $stmt->execute([
+            'species' => $speciesId,
+            'slug' => $sample['slug'],
+        ]);
+        if ($stmt->fetchColumn()) {
+            continue;
+        }
+        create_genetic_gene($pdo, array_merge($sample, ['species_id' => $speciesId]));
+    }
+}
+

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -13,6 +13,15 @@ function view(string $template, array $data = []): void
         if (!isset($data['navCareArticles']) && function_exists('get_published_care_articles')) {
             $data['navCareArticles'] = get_published_care_articles($pdo);
         }
+        if (!isset($data['settings']) && function_exists('get_all_settings')) {
+            $data['settings'] = get_all_settings($pdo);
+        }
+    }
+
+    if (!isset($data['pageMeta'])) {
+        $data['pageMeta'] = build_page_meta([], $data['settings'] ?? []);
+    } else {
+        $data['pageMeta'] = build_page_meta($data['pageMeta'], $data['settings'] ?? []);
     }
 
     extract($data);
@@ -21,7 +30,9 @@ function view(string $template, array $data = []): void
 
 function asset(string $path): string
 {
-    return BASE_URL . '/assets/' . ltrim($path, '/');
+    $assetHost = getenv('ASSET_CDN_URL');
+    $prefix = $assetHost ? rtrim($assetHost, '/') : BASE_URL;
+    return $prefix . '/assets/' . ltrim($path, '/');
 }
 
 function redirect(string $route, array $params = []): void
@@ -76,6 +87,193 @@ function ensure_directory(string $dir): void
     if (!is_dir($dir)) {
         mkdir($dir, 0775, true);
     }
+}
+
+function canonical_url(string $path = ''): string
+{
+    $cleanPath = '/' . ltrim($path ?: parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) ?: '/', '/');
+    return 'https://' . SITE_DOMAIN . $cleanPath;
+}
+
+function absolute_url(string $path = ''): string
+{
+    $cleanPath = '/' . ltrim($path, '/');
+    return 'https://' . SITE_DOMAIN . $cleanPath;
+}
+
+function get_gender_options(): array
+{
+    return [
+        'female' => ['label' => 'Weiblich', 'icon' => '♀'],
+        'male' => ['label' => 'Männlich', 'icon' => '♂'],
+        'unknown' => ['label' => 'Unbekannt', 'icon' => '⚲'],
+    ];
+}
+
+function normalize_sex(?string $value): string
+{
+    $normalized = strtolower(trim((string)$value));
+    $options = get_gender_options();
+    return array_key_exists($normalized, $options) ? $normalized : 'unknown';
+}
+
+function render_gender_field(string $name, ?string $value = null, array $options = []): string
+{
+    $legend = $options['legend'] ?? 'Geschlecht';
+    $idBase = preg_replace('/[^a-z0-9_-]/i', '_', $options['id_base'] ?? $name);
+    $required = !empty($options['required']) ? ' required' : '';
+    $current = normalize_sex($value);
+    $fieldsetClasses = trim('gender-field ' . ($options['class'] ?? ''));
+    $choiceClass = trim('gender-choice ' . ($options['choice_class'] ?? ''));
+
+    $html = '<fieldset class="' . htmlspecialchars($fieldsetClasses, ENT_QUOTES) . '">';
+    $html .= '<legend>' . htmlspecialchars($legend, ENT_QUOTES) . '</legend>';
+    $html .= '<div class="gender-options">';
+
+    foreach (get_gender_options() as $key => $meta) {
+        $id = $idBase . '-' . $key;
+        $checked = $current === $key ? ' checked' : '';
+        $html .= '<label class="' . htmlspecialchars($choiceClass, ENT_QUOTES) . '">';
+        $html .= '<input class="sr-only" type="radio" id="' . htmlspecialchars($id, ENT_QUOTES) . '" name="' . htmlspecialchars($name, ENT_QUOTES) . '" value="' . htmlspecialchars($key, ENT_QUOTES) . '"' . $checked . $required . '>';
+        $html .= '<span class="gender-choice__content">';
+        $html .= '<span class="gender-choice__icon" aria-hidden="true">' . htmlspecialchars($meta['icon'], ENT_QUOTES) . '</span>';
+        $html .= '<span class="gender-choice__label">' . htmlspecialchars($meta['label'], ENT_QUOTES) . '</span>';
+        $html .= '</span>';
+        $html .= '</label>';
+    }
+
+    $html .= '</div>';
+    $html .= '</fieldset>';
+
+    return $html;
+}
+
+function render_sex_badge(?string $value, array $options = []): string
+{
+    if ($value === null || $value === '') {
+        return '';
+    }
+
+    $sex = normalize_sex($value);
+    $genderOptions = get_gender_options();
+    if (!isset($genderOptions[$sex])) {
+        return '';
+    }
+
+    $meta = $genderOptions[$sex];
+    $tag = $options['tag'] ?? 'span';
+    $classes = trim('badge badge-gender ' . ($options['class'] ?? ''));
+    $label = $meta['label'];
+    $icon = $meta['icon'];
+
+    return sprintf(
+        '<%1$s class="%2$s" aria-label="%3$s" title="%3$s">%4$s %5$s</%1$s>',
+        $tag,
+        htmlspecialchars($classes, ENT_QUOTES),
+        htmlspecialchars($label, ENT_QUOTES),
+        htmlspecialchars($icon, ENT_QUOTES),
+        htmlspecialchars($label, ENT_QUOTES)
+    );
+}
+
+function build_page_meta(array $overrides = [], array $settings = []): array
+{
+    $path = $overrides['path'] ?? (parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) ?: '/');
+    $path = '/' . ltrim($path, '/');
+    $title = trim($overrides['title'] ?? ($settings['site_title'] ?? SITE_NAME));
+    $description = trim($overrides['description'] ?? ($settings['site_tagline'] ?? ($settings['hero_intro'] ?? PRIMARY_TOPIC)));
+    $ogImage = $overrides['og_image'] ?? ($settings['hero_image'] ?? ORG_LOGO_URL);
+    $type = $overrides['type'] ?? 'website';
+
+    $fullTitle = $title === SITE_NAME ? $title : $title . ' | ' . SITE_NAME;
+
+    return array_merge([
+        'title' => $title,
+        'full_title' => $fullTitle,
+        'description' => $description,
+        'path' => $path,
+        'canonical' => canonical_url($path),
+        'og_title' => $overrides['og_title'] ?? $title,
+        'og_description' => $overrides['og_description'] ?? $description,
+        'og_type' => $type,
+        'og_image' => $ogImage,
+        'lang' => PRIMARY_LANGUAGE,
+        'breadcrumbs' => $overrides['breadcrumbs'] ?? [],
+        'schema' => $overrides['schema'] ?? [],
+    ], $overrides);
+}
+
+function build_breadcrumbs(array $items): array
+{
+    $position = 1;
+    $trail = [];
+    foreach ($items as $item) {
+        $trail[] = [
+            'name' => $item['name'],
+            'url' => $item['url'] ?? canonical_url($item['path'] ?? ''),
+            'position' => $position++,
+        ];
+    }
+    return $trail;
+}
+
+function render_structured_data(array $blocks): string
+{
+    if (empty($blocks)) {
+        return '';
+    }
+
+    $scripts = array_map(function ($block) {
+        return '<script type="application/ld+json">' . json_encode($block, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . '</script>';
+    }, $blocks);
+
+    return implode("\n", $scripts);
+}
+
+function render_responsive_picture(?string $path, string $alt, array $options = []): string
+{
+    if (empty($path)) {
+        return '';
+    }
+
+    $breakpoints = $options['breakpoints'] ?? [480, 768, 1024, 1600];
+    $sizes = $options['sizes'] ?? '100vw';
+    $class = $options['class'] ?? '';
+    $loading = $options['loading'] ?? 'lazy';
+    $decoding = $options['decoding'] ?? 'async';
+
+    $normalized = ltrim($path, '/');
+    $base = preg_replace('/\.[^.]+$/', '', $normalized);
+    $directory = trim(dirname($base), './');
+    $filename = basename($base);
+    $prefix = 'media/generated' . ($directory ? '/' . $directory : '');
+
+    $buildSrcset = static function (string $format) use ($prefix, $filename, $breakpoints): string {
+        $parts = [];
+        foreach ($breakpoints as $width) {
+            $url = '/' . trim($prefix . '/' . $filename . '_' . $width . '.' . $format, '/');
+            $parts[] = $url . ' ' . $width . 'w';
+        }
+        return implode(', ', $parts);
+    };
+
+    $avifSrcset = $buildSrcset('avif');
+    $webpSrcset = $buildSrcset('webp');
+    $fallback = '/' . $normalized;
+
+    return sprintf(
+        '<picture><source type="image/avif" srcset="%s" sizes="%s"><source type="image/webp" srcset="%s" sizes="%s"><img src="%s" alt="%s" loading="%s" decoding="%s" sizes="%s" class="%s"></picture>',
+        htmlspecialchars($avifSrcset, ENT_QUOTES),
+        htmlspecialchars($sizes, ENT_QUOTES),
+        htmlspecialchars($webpSrcset, ENT_QUOTES),
+        htmlspecialchars($sizes, ENT_QUOTES),
+        htmlspecialchars($fallback, ENT_QUOTES),
+        htmlspecialchars($alt, ENT_QUOTES),
+        htmlspecialchars($loading, ENT_QUOTES),
+        htmlspecialchars($decoding, ENT_QUOTES),
+        htmlspecialchars($sizes, ENT_QUOTES),
+        htmlspecialchars($class, ENT_QUOTES)
+    );
 }
 
 function handle_upload(array $file): ?string

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -5,6 +5,16 @@ function view(string $template, array $data = []): void
         $data['currentRoute'] = $GLOBALS['currentRoute'];
     }
 
+    global $pdo;
+    if (isset($pdo)) {
+        if (!isset($data['navPages']) && function_exists('get_navigation_pages')) {
+            $data['navPages'] = get_navigation_pages($pdo);
+        }
+        if (!isset($data['navCareArticles']) && function_exists('get_published_care_articles')) {
+            $data['navCareArticles'] = get_published_care_articles($pdo);
+        }
+    }
+
     extract($data);
     include __DIR__ . '/../public/views/' . $template . '.php';
 }
@@ -96,4 +106,51 @@ function set_setting(PDO $pdo, string $key, string $value): void
 {
     $stmt = $pdo->prepare('REPLACE INTO settings(key, value) VALUES (:key, :value)');
     $stmt->execute(['key' => $key, 'value' => $value]);
+}
+
+function slugify(string $value): string
+{
+    $transliterated = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $value);
+    if ($transliterated !== false) {
+        $value = $transliterated;
+    }
+    $value = strtolower(trim($value));
+    $value = preg_replace('/[^a-z0-9]+/i', '-', $value);
+    $value = trim($value, '-');
+    return $value ?: bin2hex(random_bytes(4));
+}
+
+function ensure_unique_slug(PDO $pdo, string $table, string $slug, ?int $ignoreId = null): string
+{
+    $base = $slug ?: bin2hex(random_bytes(4));
+    $candidate = $base;
+    $counter = 1;
+
+    while (true) {
+        $sql = "SELECT COUNT(*) FROM {$table} WHERE slug = :slug";
+        $params = ['slug' => $candidate];
+        if ($ignoreId !== null) {
+            $sql .= ' AND id != :id';
+            $params['id'] = $ignoreId;
+        }
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute($params);
+        if ($stmt->fetchColumn() == 0) {
+            return $candidate;
+        }
+        $candidate = $base . '-' . (++$counter);
+    }
+}
+
+function render_rich_text(?string $value): string
+{
+    if ($value === null || $value === '') {
+        return '';
+    }
+
+    if (strpos($value, '<') === false) {
+        return nl2br(htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'));
+    }
+
+    return $value;
 }

--- a/app/news.php
+++ b/app/news.php
@@ -1,0 +1,75 @@
+<?php
+function create_news(PDO $pdo, array $data): int
+{
+    $slug = $data['slug'] ?: slugify($data['title']);
+    $slug = ensure_unique_slug($pdo, 'news_posts', $slug);
+    $publishedAt = !empty($data['is_published']) ? ($data['published_at'] ?: date('c')) : null;
+    $stmt = $pdo->prepare('INSERT INTO news_posts(title, slug, excerpt, content, is_published, published_at) VALUES (:title, :slug, :excerpt, :content, :is_published, :published_at)');
+    $stmt->execute([
+        'title' => $data['title'],
+        'slug' => $slug,
+        'excerpt' => $data['excerpt'] ?? null,
+        'content' => $data['content'],
+        'is_published' => !empty($data['is_published']) ? 1 : 0,
+        'published_at' => $publishedAt,
+    ]);
+    return (int)$pdo->lastInsertId();
+}
+
+function update_news(PDO $pdo, int $id, array $data): void
+{
+    $slug = $data['slug'] ?: slugify($data['title']);
+    $slug = ensure_unique_slug($pdo, 'news_posts', $slug, $id);
+    $publishedAt = !empty($data['is_published']) ? ($data['published_at'] ?: date('c')) : null;
+    $stmt = $pdo->prepare('UPDATE news_posts SET title = :title, slug = :slug, excerpt = :excerpt, content = :content, is_published = :is_published, published_at = :published_at, updated_at = CURRENT_TIMESTAMP WHERE id = :id');
+    $stmt->execute([
+        'title' => $data['title'],
+        'slug' => $slug,
+        'excerpt' => $data['excerpt'] ?? null,
+        'content' => $data['content'],
+        'is_published' => !empty($data['is_published']) ? 1 : 0,
+        'published_at' => $publishedAt,
+        'id' => $id,
+    ]);
+}
+
+function delete_news(PDO $pdo, int $id): void
+{
+    $stmt = $pdo->prepare('DELETE FROM news_posts WHERE id = :id');
+    $stmt->execute(['id' => $id]);
+}
+
+function get_news(PDO $pdo): array
+{
+    return $pdo->query('SELECT * FROM news_posts ORDER BY COALESCE(published_at, created_at) DESC')->fetchAll();
+}
+
+function get_news_post(PDO $pdo, int $id): ?array
+{
+    $stmt = $pdo->prepare('SELECT * FROM news_posts WHERE id = :id');
+    $stmt->execute(['id' => $id]);
+    $post = $stmt->fetch();
+    return $post ?: null;
+}
+
+function get_news_by_slug(PDO $pdo, string $slug): ?array
+{
+    $stmt = $pdo->prepare('SELECT * FROM news_posts WHERE slug = :slug');
+    $stmt->execute(['slug' => $slug]);
+    $post = $stmt->fetch();
+    return $post ?: null;
+}
+
+function get_published_news(PDO $pdo): array
+{
+    return $pdo->query('SELECT * FROM news_posts WHERE is_published = 1 ORDER BY COALESCE(published_at, created_at) DESC')->fetchAll();
+}
+
+function get_latest_published_news(PDO $pdo, int $limit = 3): array
+{
+    $stmt = $pdo->prepare('SELECT * FROM news_posts WHERE is_published = 1 ORDER BY COALESCE(published_at, created_at) DESC LIMIT :limit');
+    $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+    $stmt->execute();
+    return $stmt->fetchAll();
+}
+

--- a/app/pages.php
+++ b/app/pages.php
@@ -1,0 +1,119 @@
+<?php
+function create_page(PDO $pdo, array $data): int
+{
+    $slug = $data['slug'] ?: slugify($data['title']);
+    $slug = ensure_unique_slug($pdo, 'pages', $slug);
+    $parentId = normalize_page_parent($pdo, $data['parent_id'] ?? null);
+    $stmt = $pdo->prepare('INSERT INTO pages(title, slug, content, is_published, show_in_menu, parent_id, menu_order) VALUES (:title, :slug, :content, :is_published, :show_in_menu, :parent_id, :menu_order)');
+    $stmt->execute([
+        'title' => $data['title'],
+        'slug' => $slug,
+        'content' => $data['content'],
+        'is_published' => !empty($data['is_published']) ? 1 : 0,
+        'show_in_menu' => !empty($data['show_in_menu']) ? 1 : 0,
+        'parent_id' => $parentId,
+        'menu_order' => isset($data['menu_order']) ? (int)$data['menu_order'] : 0,
+    ]);
+    return (int)$pdo->lastInsertId();
+}
+
+function update_page(PDO $pdo, int $id, array $data): void
+{
+    $slug = $data['slug'] ?: slugify($data['title']);
+    $slug = ensure_unique_slug($pdo, 'pages', $slug, $id);
+    $parentId = normalize_page_parent($pdo, $data['parent_id'] ?? null, $id);
+    $stmt = $pdo->prepare('UPDATE pages SET title = :title, slug = :slug, content = :content, is_published = :is_published, show_in_menu = :show_in_menu, parent_id = :parent_id, menu_order = :menu_order, updated_at = CURRENT_TIMESTAMP WHERE id = :id');
+    $stmt->execute([
+        'title' => $data['title'],
+        'slug' => $slug,
+        'content' => $data['content'],
+        'is_published' => !empty($data['is_published']) ? 1 : 0,
+        'show_in_menu' => !empty($data['show_in_menu']) ? 1 : 0,
+        'parent_id' => $parentId,
+        'menu_order' => isset($data['menu_order']) ? (int)$data['menu_order'] : 0,
+        'id' => $id,
+    ]);
+}
+
+function delete_page(PDO $pdo, int $id): void
+{
+    $pdo->prepare('UPDATE pages SET parent_id = NULL WHERE parent_id = :id')->execute(['id' => $id]);
+    $stmt = $pdo->prepare('DELETE FROM pages WHERE id = :id');
+    $stmt->execute(['id' => $id]);
+}
+
+function get_page(PDO $pdo, int $id): ?array
+{
+    $stmt = $pdo->prepare('SELECT * FROM pages WHERE id = :id');
+    $stmt->execute(['id' => $id]);
+    $page = $stmt->fetch();
+    return $page ?: null;
+}
+
+function get_page_by_slug(PDO $pdo, string $slug): ?array
+{
+    $stmt = $pdo->prepare('SELECT * FROM pages WHERE slug = :slug');
+    $stmt->execute(['slug' => $slug]);
+    $page = $stmt->fetch();
+    return $page ?: null;
+}
+
+function get_pages(PDO $pdo): array
+{
+    return $pdo->query('SELECT * FROM pages ORDER BY title COLLATE NOCASE ASC')->fetchAll();
+}
+
+function get_published_pages(PDO $pdo): array
+{
+    return $pdo->query('SELECT * FROM pages WHERE is_published = 1 ORDER BY title COLLATE NOCASE ASC')->fetchAll();
+}
+
+function get_navigation_pages(PDO $pdo): array
+{
+    $pages = $pdo->query('SELECT * FROM pages WHERE is_published = 1 AND show_in_menu = 1 ORDER BY menu_order ASC, title COLLATE NOCASE ASC')->fetchAll();
+    $pagesById = [];
+    foreach ($pages as $page) {
+        $pagesById[$page['id']] = $page;
+    }
+
+    $children = [];
+    foreach ($pages as $page) {
+        $parentId = (int)($page['parent_id'] ?? 0);
+        if ($parentId && !isset($pagesById[$parentId])) {
+            $parentId = 0;
+        }
+        $children[$parentId][] = $page;
+    }
+
+    return build_page_navigation_tree($children, 0);
+}
+
+function build_page_navigation_tree(array $children, int $parentId): array
+{
+    $branch = [];
+    foreach ($children[$parentId] ?? [] as $page) {
+        $page['children'] = build_page_navigation_tree($children, (int)$page['id']);
+        $branch[] = $page;
+    }
+    return $branch;
+}
+
+function normalize_page_parent(PDO $pdo, $parentId, ?int $currentId = null): ?int
+{
+    if ($parentId === null || $parentId === '') {
+        return null;
+    }
+
+    $parentId = (int)$parentId;
+    if ($currentId !== null && $parentId === $currentId) {
+        return null;
+    }
+
+    $parent = get_page($pdo, $parentId);
+    if (!$parent) {
+        return null;
+    }
+
+    return $parentId;
+}
+

--- a/app/site.php
+++ b/app/site.php
@@ -1,0 +1,12 @@
+<?php
+const SITE_NAME = 'FeroxZ Reptile Center';
+const SITE_DOMAIN = 'bartagame.eu';
+const PRIMARY_TOPIC = 'Bartagamen, Reptilienhaltung, Genetik, Tierabgabe';
+const PRIMARY_LANGUAGE = 'de';
+const CONTACT_EMAIL = 'info@bartagame.eu';
+const ORG_NAME = 'FeroxZ Reptile Center';
+const ORG_LOGO_URL = 'https://bartagame.eu/static/logo.png';
+const ORG_SAME_AS = [
+    'https://www.instagram.com/...',
+    'https://www.facebook.com/...',
+];

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "feroxz-site",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build:images": "php scripts/generate-responsive-images.php",
+    "audit": "npm run audit:lighthouse && npm run audit:html && npm run audit:schema",
+    "audit:lighthouse": "lhci autorun --config=./scripts/lhci.config.js",
+    "audit:html": "html-validator --url http://localhost:8080 --format text --is-local --validator https://validator.w3.org/nu/ > reports/html-validation.txt",
+    "audit:schema": "node scripts/schema-check.mjs"
+  },
+  "devDependencies": {
+    "@lhci/cli": "^0.11.0",
+    "html-validator-cli": "^7.1.1",
+    "node-fetch": "^3.3.2"
+  }
+}

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,32 @@
+<IfModule mod_rewrite.c>
+  RewriteEngine On
+  RewriteRule ^sitemap\.xml$ sitemap.php [L]
+</IfModule>
+
+<IfModule mod_expires.c>
+  ExpiresActive On
+  ExpiresByType text/css "access plus 7 days"
+  ExpiresByType application/javascript "access plus 7 days"
+  ExpiresByType image/png "access plus 1 year"
+  ExpiresByType image/jpeg "access plus 1 year"
+  ExpiresByType image/webp "access plus 1 year"
+  ExpiresByType image/avif "access plus 1 year"
+  ExpiresByType image/svg+xml "access plus 1 year"
+</IfModule>
+
+<IfModule mod_headers.c>
+  <FilesMatch "\.(css|js)$">
+    Header set Cache-Control "public, max-age=604800"
+  </FilesMatch>
+  <FilesMatch "\.(png|jpe?g|gif|webp|avif|svg)$">
+    Header set Cache-Control "public, max-age=31536000, immutable"
+  </FilesMatch>
+</IfModule>
+
+FileETag None
+<IfModule mod_headers.c>
+  Header unset ETag
+  Header set X-Content-Type-Options "nosniff"
+  Header set Referrer-Policy "strict-origin-when-cross-origin"
+  Header set Permissions-Policy "geolocation=()"
+</IfModule>

--- a/public/assets/admin.js
+++ b/public/assets/admin.js
@@ -1,0 +1,76 @@
+(function () {
+    if (typeof document === 'undefined') {
+        return;
+    }
+
+    function createButton(label, title, onClick) {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'rich-text-btn';
+        button.innerHTML = label;
+        button.title = title;
+        button.addEventListener('click', (event) => {
+            event.preventDefault();
+            onClick();
+        });
+        return button;
+    }
+
+    function wrapTextarea(textarea) {
+        if (textarea.dataset.richTextified) {
+            return;
+        }
+        textarea.dataset.richTextified = 'true';
+
+        const wrapper = document.createElement('div');
+        wrapper.className = 'rich-text-wrapper';
+
+        const toolbar = document.createElement('div');
+        toolbar.className = 'rich-text-toolbar';
+
+        const editor = document.createElement('div');
+        editor.className = 'rich-text-editor';
+        editor.contentEditable = 'true';
+        editor.innerHTML = textarea.value;
+
+        const commands = [
+            { label: '<strong>B</strong>', title: 'Fett', action: () => document.execCommand('bold', false) },
+            { label: '<em>I</em>', title: 'Kursiv', action: () => document.execCommand('italic', false) },
+            { label: '<u>U</u>', title: 'Unterstrichen', action: () => document.execCommand('underline', false) },
+            { label: '&#8226;', title: 'Aufzählung', action: () => document.execCommand('insertUnorderedList', false) },
+            { label: '&#35;', title: 'Nummerierung', action: () => document.execCommand('insertOrderedList', false) },
+            { label: '&#128279;', title: 'Link einfügen', action: () => {
+                const url = window.prompt('Link-Adresse (inkl. https://)');
+                if (url) {
+                    document.execCommand('createLink', false, url);
+                }
+            } },
+            { label: '&#9003;', title: 'Formatierung löschen', action: () => document.execCommand('removeFormat', false) }
+        ];
+
+        commands.forEach((command) => toolbar.appendChild(createButton(command.label, command.title, command.action)));
+
+        textarea.style.display = 'none';
+        textarea.parentNode.insertBefore(wrapper, textarea);
+        wrapper.appendChild(toolbar);
+        wrapper.appendChild(editor);
+        wrapper.appendChild(textarea);
+
+        const sync = () => {
+            textarea.value = editor.innerHTML.trim();
+        };
+
+        editor.addEventListener('input', sync);
+        editor.addEventListener('blur', sync);
+
+        const form = textarea.closest('form');
+        if (form) {
+            form.addEventListener('submit', sync);
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        document.querySelectorAll('textarea.rich-text').forEach(wrapTextarea);
+    });
+})();
+

--- a/public/assets/genetics.js
+++ b/public/assets/genetics.js
@@ -1,0 +1,306 @@
+(function () {
+    if (typeof document === 'undefined') {
+        return;
+    }
+    const root = document.querySelector('[data-genetic-selector]');
+    const geneData = window.GENETIC_GENE_DATA || [];
+    if (!root || !Array.isArray(geneData) || geneData.length === 0) {
+        return;
+    }
+
+    const parentSelections = window.GENETIC_PARENT_SELECTIONS || { parent1: {}, parent2: {} };
+    const errorPanel = root.querySelector('[data-form-error]');
+    const genesById = new Map();
+    const searchIndex = [];
+
+    function normalize(value) {
+        return value
+            .toString()
+            .normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, '')
+            .toLowerCase();
+    }
+
+    geneData.forEach((gene) => {
+        genesById.set(gene.id, gene);
+        (gene.states || []).forEach((state) => {
+            const tokens = Array.isArray(state.searchTokens) ? state.searchTokens.slice() : [];
+            tokens.push(gene.name || '');
+            if (gene.shorthand) {
+                tokens.push(gene.shorthand);
+            }
+            const normalizedTokens = tokens
+                .filter(Boolean)
+                .map((token) => normalize(token));
+            searchIndex.push({
+                geneId: gene.id,
+                stateKey: state.key,
+                stateLabel: state.label,
+                geneName: gene.name,
+                display: `${state.label} – ${gene.name}`,
+                tokens: Array.from(new Set(normalizedTokens)),
+            });
+        });
+    });
+
+    function findState(geneId, stateKey) {
+        const gene = genesById.get(geneId);
+        if (!gene) {
+            return null;
+        }
+        return (gene.states || []).find((state) => state.key === stateKey) || null;
+    }
+
+    function buildSelectionMap(defaults) {
+        const map = new Map();
+        Object.entries(defaults || {}).forEach(([geneId, stateKey]) => {
+            const numericId = Number(geneId);
+            const state = findState(numericId, stateKey);
+            if (state) {
+                map.set(numericId, stateKey);
+            }
+        });
+        return map;
+    }
+
+    const selections = {
+        parent1: buildSelectionMap(parentSelections.parent1),
+        parent2: buildSelectionMap(parentSelections.parent2),
+    };
+
+    function showError(message) {
+        if (!errorPanel) {
+            return;
+        }
+        errorPanel.textContent = message;
+        errorPanel.hidden = false;
+    }
+
+    function clearError() {
+        if (!errorPanel) {
+            return;
+        }
+        errorPanel.textContent = '';
+        errorPanel.hidden = true;
+    }
+
+    function renderTags(parentKey) {
+        const container = root.querySelector(`[data-parent="${parentKey}"] [data-tag-container]`);
+        const hiddenInputs = root.querySelector(`[data-parent="${parentKey}"] [data-hidden-inputs]`);
+        if (!container || !hiddenInputs) {
+            return;
+        }
+        container.innerHTML = '';
+        container.dataset.hasSelection = 'false';
+        hiddenInputs.innerHTML = '';
+        const entries = Array.from(selections[parentKey].entries()).sort((a, b) => {
+            const geneA = genesById.get(a[0]);
+            const geneB = genesById.get(b[0]);
+            const nameA = geneA ? geneA.name : '';
+            const nameB = geneB ? geneB.name : '';
+            return nameA.localeCompare(nameB, 'de');
+        });
+
+        if (!entries.length) {
+            const placeholder = document.createElement('span');
+            placeholder.className = 'gene-multiselect__placeholder';
+            placeholder.textContent = container.dataset.placeholder || 'Wildtyp';
+            container.appendChild(placeholder);
+        }
+
+        entries.forEach(([geneId, stateKey]) => {
+            const gene = genesById.get(geneId);
+            const state = findState(geneId, stateKey);
+            if (!gene || !state) {
+                return;
+            }
+            const tag = document.createElement('span');
+            tag.className = 'gene-chip';
+            const label = document.createElement('span');
+            label.className = 'gene-chip__label';
+            label.textContent = `${gene.name}: ${state.label}`;
+            const remove = document.createElement('button');
+            remove.type = 'button';
+            remove.className = 'gene-chip__remove';
+            remove.setAttribute('aria-label', `${gene.name} entfernen`);
+            remove.textContent = '×';
+            remove.addEventListener('click', () => {
+                selections[parentKey].delete(geneId);
+                renderTags(parentKey);
+                clearError();
+            });
+            tag.appendChild(label);
+            tag.appendChild(remove);
+            container.appendChild(tag);
+
+            const input = document.createElement('input');
+            input.type = 'hidden';
+            input.name = `${parentKey}[${geneId}]`;
+            input.value = stateKey;
+            hiddenInputs.appendChild(input);
+        });
+        container.dataset.hasSelection = entries.length ? 'true' : 'false';
+    }
+
+    function renderSuggestions(parentKey, suggestions, container, input, query) {
+        container.innerHTML = '';
+        if (!suggestions.length) {
+            const empty = document.createElement('div');
+            empty.className = 'gene-suggestion gene-suggestion--empty';
+            empty.textContent = 'Keine passenden Einträge gefunden.';
+            container.appendChild(empty);
+            container.hidden = false;
+            if (query) {
+                showError('Keine Übereinstimmung gefunden. Bitte prüfen Sie die Schreibweise oder pflegen Sie das Gen im Adminbereich.');
+            }
+            return;
+        }
+        clearError();
+        const limited = suggestions
+            .slice()
+            .filter((entry) => entry)
+            .sort((a, b) => a.geneName.localeCompare(b.geneName, 'de', { sensitivity: 'base' }))
+            .slice(0, 10);
+        limited.forEach((entry) => {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = 'gene-suggestion';
+            button.innerHTML = `<strong>${entry.stateLabel}</strong><span>${entry.geneName}</span>`;
+            button.addEventListener('click', () => {
+                selections[parentKey].set(entry.geneId, entry.stateKey);
+                renderTags(parentKey);
+                container.hidden = true;
+                container.innerHTML = '';
+                if (input) {
+                    input.value = '';
+                }
+                clearError();
+            });
+            container.appendChild(button);
+        });
+        container.hidden = false;
+    }
+
+    function handleParent(parentKey) {
+        const parentRoot = root.querySelector(`[data-parent="${parentKey}"]`);
+        if (!parentRoot) {
+            return null;
+        }
+        const input = parentRoot.querySelector('[data-input]');
+        const suggestionContainer = parentRoot.querySelector('[data-suggestions]');
+        const clearButton = parentRoot.querySelector('[data-clear]');
+        if (!input || !suggestionContainer) {
+            return {
+                clearAll() {
+                    selections[parentKey].clear();
+                    renderTags(parentKey);
+                },
+            };
+        }
+
+        input.addEventListener('input', () => {
+            const value = input.value.trim();
+            const normalized = normalize(value);
+            if (!normalized) {
+                suggestionContainer.hidden = true;
+                suggestionContainer.innerHTML = '';
+                clearError();
+                return;
+            }
+            const matches = searchIndex.filter((entry) => {
+                if (selections[parentKey].get(entry.geneId) === entry.stateKey) {
+                    return false;
+                }
+                return entry.tokens.some((token) => token.includes(normalized));
+            });
+            renderSuggestions(parentKey, matches, suggestionContainer, input, value);
+        });
+
+        input.addEventListener('keydown', (event) => {
+            if (event.key === 'Backspace' && !input.value && input.selectionStart === 0 && input.selectionEnd === 0) {
+                const keys = Array.from(selections[parentKey].keys());
+                const lastKey = keys.pop();
+                if (typeof lastKey !== 'undefined') {
+                    selections[parentKey].delete(lastKey);
+                    renderTags(parentKey);
+                    clearError();
+                }
+            }
+            if (event.key === 'Enter') {
+                const value = input.value.trim();
+                const normalized = normalize(value);
+                if (!normalized) {
+                    return;
+                }
+                const match = searchIndex.find((entry) => {
+                    if (selections[parentKey].get(entry.geneId) === entry.stateKey) {
+                        return false;
+                    }
+                    return entry.tokens.some((token) => token.includes(normalized));
+                });
+                if (match) {
+                    event.preventDefault();
+                    selections[parentKey].set(match.geneId, match.stateKey);
+                    renderTags(parentKey);
+                    suggestionContainer.hidden = true;
+                    suggestionContainer.innerHTML = '';
+                    input.value = '';
+                    clearError();
+                }
+                if (!match) {
+                    showError('Eingabe konnte keinem bekannten Gen zugeordnet werden. Bitte wählen Sie einen Vorschlag aus der Liste.');
+                }
+            } else if (event.key === 'Escape') {
+                suggestionContainer.hidden = true;
+            }
+        });
+
+        input.addEventListener('focus', () => {
+            if (input.value.trim().length === 0) {
+                const suggestions = searchIndex.filter((entry) => selections[parentKey].get(entry.geneId) !== entry.stateKey);
+                renderSuggestions(parentKey, suggestions, suggestionContainer, input, '');
+            }
+        });
+
+        document.addEventListener('click', (event) => {
+            if (!parentRoot.contains(event.target)) {
+                suggestionContainer.hidden = true;
+            }
+        });
+
+        function clearAllSelections() {
+            selections[parentKey].clear();
+            renderTags(parentKey);
+            suggestionContainer.hidden = true;
+            suggestionContainer.innerHTML = '';
+            if (input) {
+                input.value = '';
+            }
+            clearError();
+        }
+
+        clearButton?.addEventListener('click', clearAllSelections);
+        renderTags(parentKey);
+        return {
+            clearAll: clearAllSelections,
+        };
+    }
+
+    const controllers = {
+        parent1: handleParent('parent1'),
+        parent2: handleParent('parent2'),
+    };
+
+    const clearAllButton = root.querySelector('[data-clear-all]');
+    if (clearAllButton) {
+        clearAllButton.addEventListener('click', () => {
+            Object.values(controllers).forEach((controller) => {
+                controller?.clearAll?.();
+            });
+        });
+    }
+
+    root.addEventListener('submit', () => {
+        clearError();
+    });
+})();

--- a/public/assets/style.css
+++ b/public/assets/style.css
@@ -1,90 +1,79 @@
 :root {
-  --surface: rgba(15, 23, 42, 0.78);
-  --surface-soft: rgba(15, 23, 42, 0.58);
-  --surface-strong: rgba(15, 23, 42, 0.92);
-  --border: rgba(148, 163, 184, 0.25);
-  --border-strong: rgba(34, 211, 238, 0.45);
-  --accent: #22d3ee;
-  --accent-strong: #06b6d4;
-  --text: #e2e8f0;
-  --text-muted: #94a3b8;
-  --success: #34d399;
-  --danger: #fb7185;
-  --danger-border: rgba(248, 113, 113, 0.35);
+  color-scheme: dark;
+  --bg-main: #050918;
+  --bg-glow: radial-gradient(circle at top right, rgba(0, 188, 212, 0.14), transparent 55%), radial-gradient(circle at 15% 85%, rgba(255, 115, 35, 0.22), transparent 58%), linear-gradient(135deg, #050918 0%, #0a132b 55%, #02070f 100%);
+  --surface: rgba(11, 20, 40, 0.72);
+  --surface-strong: rgba(13, 29, 60, 0.92);
+  --surface-soft: rgba(10, 18, 34, 0.58);
+  --surface-glass: rgba(255, 255, 255, 0.06);
+  --border: rgba(135, 200, 255, 0.25);
+  --border-strong: rgba(70, 150, 255, 0.48);
+  --accent: #5b8eff;
+  --accent-soft: rgba(91, 142, 255, 0.16);
+  --accent-strong: #7fd1ff;
+  --accent-warm: #ff934f;
+  --text: #f2f6ff;
+  --text-soft: rgba(228, 237, 255, 0.68);
+  --text-faint: rgba(215, 225, 247, 0.42);
+  --danger: #ff6b6b;
+  --success: #6bffcf;
+  --warning: #ffd166;
+  --shadow-soft: 0 45px 120px rgba(5, 12, 30, 0.65);
+  --shadow-inner: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  --radius-xl: 34px;
+  --radius-lg: 24px;
+  --radius-md: 18px;
+  --radius-sm: 12px;
+  --content-max: min(1480px, 100%);
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
 }
 
-main h1 {
-  font-size: clamp(2rem, 2.8vw, 3.2rem);
-  font-weight: 600;
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-glow);
+  background-attachment: fixed;
   color: var(--text);
-  margin-bottom: 1.5rem;
-}
-
-main h2 {
-  font-size: clamp(1.4rem, 2vw, 2rem);
-  font-weight: 600;
-  color: var(--text);
-  margin: 1.5rem 0 0.75rem;
-}
-
-main h3 {
-  font-size: clamp(1.15rem, 1.6vw, 1.5rem);
-  font-weight: 600;
-  color: var(--text);
-  margin: 1.25rem 0 0.5rem;
-}
-
-main p {
-  color: var(--text-muted);
+  font-family: inherit;
   line-height: 1.6;
+  letter-spacing: -0.01em;
+  -webkit-font-smoothing: antialiased;
 }
 
-.grid {
-  display: grid;
-  gap: 1.5rem;
+main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  padding: 0;
 }
 
-.grid.cards {
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+img {
+  max-width: 100%;
+  display: block;
+  border-radius: var(--radius-md);
 }
 
-.card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 1.5rem;
-  padding: 1.5rem;
-  box-shadow: 0 18px 45px rgba(8, 47, 73, 0.35);
-  color: var(--text);
+picture img {
+  width: 100%;
+  height: auto;
+  object-fit: cover;
 }
 
-.card > h2,
-.card > h3 {
-  margin-top: 0;
-}
-
-.stack {
-  display: grid;
-  gap: 1.25rem;
-}
-
-.badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 999px;
-  padding: 0.25rem 0.75rem;
-  background: rgba(34, 211, 238, 0.16);
-  color: var(--accent);
-  font-size: 0.7rem;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.badge-pattern {
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.85), rgba(148, 163, 184, 0.3));
-  color: #0f172a;
-  border: 1px solid rgba(148, 163, 184, 0.45);
+a {
+  color: var(--accent-strong);
+  text-decoration: none;
+  transition: color 200ms ease, opacity 200ms ease, transform 200ms ease;
 }
 
 .sr-only {
@@ -99,543 +88,1239 @@ main p {
   border: 0;
 }
 
-.animal-marker {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  margin-left: 0.35rem;
-  font-size: 0.85rem;
+a:hover,
+a:focus-visible {
   color: var(--accent);
 }
 
-.btn,
-.card a.btn,
-.card a.btn-secondary {
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible {
+  outline: 2px solid var(--accent-strong);
+  outline-offset: 2px;
+}
+
+button {
+  font: inherit;
+  cursor: pointer;
+  color: inherit;
+  background: none;
+  border: none;
+}
+
+.skip-link {
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
+  z-index: 200;
+  padding: 0.75rem 1.25rem;
+  border-radius: var(--radius-sm);
+  background: var(--accent);
+  color: #020509;
+  font-weight: 600;
+  transform: translateY(-200%);
+  transition: transform 200ms ease;
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 90;
+  backdrop-filter: blur(18px);
+  background: rgba(5, 9, 24, 0.88);
+  border-bottom: 1px solid rgba(120, 170, 255, 0.2);
+}
+
+.site-header__bar {
+  margin: 0 auto;
+  width: var(--content-max);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: clamp(1.2rem, 1vw + 1rem, 1.75rem) clamp(2rem, 4vw, 5rem);
+}
+
+.site-header__brand {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  gap: 0.35rem;
+  gap: 1rem;
+  padding: 0.4rem 0.85rem;
   border-radius: 999px;
-  padding: 0.55rem 1.2rem;
-  font-weight: 600;
+  background: var(--surface);
+  border: 1px solid rgba(135, 200, 255, 0.3);
+  box-shadow: var(--shadow-inner);
+}
+
+.site-header__brand-logo {
+  display: grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background: linear-gradient(140deg, rgba(91, 142, 255, 0.28), rgba(127, 209, 255, 0.12));
+  border: 1px solid rgba(127, 209, 255, 0.35);
+  font-weight: 700;
+  letter-spacing: 0.1em;
+}
+
+.site-header__brand-copy {
+  display: flex;
+  flex-direction: column;
   font-size: 0.85rem;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
-  transition: all 0.2s ease;
-  border: 1px solid var(--border-strong);
-  background: rgba(34, 211, 238, 0.15);
-  color: var(--accent);
+  letter-spacing: 0.28em;
+  color: var(--text-faint);
 }
 
-.btn-secondary {
-  border-color: rgba(148, 163, 184, 0.35);
-  background: rgba(148, 163, 184, 0.12);
+.site-header__brand-copy strong {
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.16em;
   color: var(--text);
+  text-transform: none;
 }
 
-.btn:hover,
-.btn-secondary:hover {
-  border-color: var(--accent);
-  background: rgba(34, 211, 238, 0.22);
+.site-header__toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 18px;
+  border: 1px solid rgba(127, 209, 255, 0.3);
+  background: rgba(127, 209, 255, 0.08);
   color: var(--text);
-  box-shadow: 0 12px 30px rgba(6, 182, 212, 0.25);
+  transition: border 200ms ease, background 200ms ease, transform 200ms ease;
+}
+
+.site-header__toggle:hover {
+  border-color: rgba(127, 209, 255, 0.7);
+  background: rgba(127, 209, 255, 0.15);
   transform: translateY(-1px);
 }
 
-.alert {
-  border-radius: 1rem;
-  padding: 0.75rem 1rem;
+.site-nav {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+.site-nav__link {
+  padding: 0.65rem 1.15rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-soft);
+  transition: border 200ms ease, background 200ms ease, color 200ms ease, box-shadow 200ms ease;
+}
+
+.site-nav__link:hover,
+.site-nav__link:focus-visible {
+  color: var(--text);
+  border-color: rgba(127, 209, 255, 0.45);
+  background: rgba(127, 209, 255, 0.12);
+  box-shadow: 0 12px 30px rgba(91, 142, 255, 0.18);
+}
+
+.site-nav__link--active {
+  color: var(--bg-main);
+  background: linear-gradient(135deg, #7fd1ff, #5b8eff);
+  border-color: transparent;
+  box-shadow: 0 18px 45px rgba(91, 142, 255, 0.35);
+}
+
+.site-nav__group {
+  position: relative;
+}
+
+.site-nav__dropdown {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 0.5rem);
+  min-width: 220px;
+  padding: 0.75rem;
+  border-radius: var(--radius-md);
+  background: var(--surface-strong);
+  border: 1px solid rgba(127, 209, 255, 0.25);
+  box-shadow: var(--shadow-soft);
+  display: none;
+}
+
+.site-nav__dropdown a,
+.site-nav__dropdown-link {
+  display: block;
+  padding: 0.65rem 0.75rem;
+  border-radius: var(--radius-sm);
+  color: var(--text-soft);
+}
+
+.site-nav__dropdown a:hover,
+.site-nav__dropdown a:focus-visible,
+.site-nav__dropdown-link:hover,
+.site-nav__dropdown-link:focus-visible {
+  background: rgba(127, 209, 255, 0.1);
+  color: var(--text);
+}
+
+.site-nav__group.open .site-nav__dropdown {
+  display: block;
+}
+
+@media (max-width: 1080px) {
+  .site-header__toggle {
+    display: inline-flex;
+  }
+
+  .site-nav {
+    position: fixed;
+    inset: 72px 1.25rem auto;
+    width: calc(100% - 2.5rem);
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.5rem;
+    padding: 1.2rem;
+    border-radius: var(--radius-lg);
+    background: rgba(5, 13, 30, 0.94);
+    border: 1px solid rgba(127, 209, 255, 0.2);
+    box-shadow: var(--shadow-soft);
+    transform-origin: top right;
+    transform: scale(0.95) translateY(-10px);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 200ms ease, transform 220ms ease;
+  }
+
+  .site-nav[data-open="true"] {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+    pointer-events: auto;
+  }
+
+  .site-nav__group {
+    width: 100%;
+  }
+
+  .site-nav__group .site-nav__dropdown {
+    position: static;
+    display: block;
+    margin-top: 0.4rem;
+    background: rgba(10, 22, 42, 0.85);
+    border: 1px solid rgba(127, 209, 255, 0.22);
+    box-shadow: none;
+  }
+
+  .site-nav__link,
+  .site-nav__dropdown a {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+
+.section {
+  width: 100%;
+  padding: clamp(3.5rem, 8vw, 8rem) clamp(1.5rem, 7vw, 8rem);
+}
+
+.section--hero {
+  min-height: min(100vh, 980px);
+  display: flex;
+  align-items: stretch;
+  padding-block: clamp(4rem, 9vw, 10rem);
+}
+
+.section__inner {
+  width: var(--content-max);
+  margin: 0 auto;
+  display: grid;
+  gap: clamp(2rem, 3vw, 3.5rem);
+}
+
+.section--hero .section__inner {
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  align-items: center;
+}
+
+.hero-panel {
+  border-radius: var(--radius-xl);
+  border: 1px solid rgba(127, 209, 255, 0.25);
+  padding: clamp(2.25rem, 3vw, 3.5rem);
+  background: linear-gradient(160deg, rgba(12, 26, 55, 0.72), rgba(33, 72, 125, 0.62));
+  box-shadow: var(--shadow-soft);
+  position: relative;
+  overflow: hidden;
+}
+
+.hero-panel::after {
+  content: "";
+  position: absolute;
+  inset: auto -20% -35% -10%;
+  height: 220px;
+  background: radial-gradient(circle at top, rgba(127, 209, 255, 0.22), transparent 65%);
+  filter: blur(0px);
+  pointer-events: none;
+}
+
+.hero-panel__kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(91, 142, 255, 0.18);
+  border: 1px solid rgba(127, 209, 255, 0.35);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+}
+
+.hero-panel__title {
+  font-size: clamp(2.8rem, 3.6vw, 4.1rem);
+  font-weight: 700;
+  line-height: 1.12;
+  margin-block: clamp(1.1rem, 2vw, 2.4rem) clamp(1.4rem, 3vw, 2.8rem);
+}
+
+.hero-panel__body {
+  font-size: 1.05rem;
+  color: var(--text-soft);
+  max-width: 60ch;
+}
+
+.hero-panel__bullets {
+  display: grid;
+  gap: 0.85rem;
+  margin-top: clamp(1.6rem, 3vw, 2.4rem);
+}
+
+.hero-panel__bullets li {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: start;
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-md);
+  background: rgba(8, 18, 40, 0.72);
+  border: 1px solid rgba(127, 209, 255, 0.2);
+}
+
+.hero-panel__bullets span:first-child {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #7fd1ff, #5b8eff);
+  margin-top: 0.2rem;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: clamp(1.8rem, 3vw, 2.6rem);
+}
+
+.button,
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.65rem;
+  padding: 0.85rem 1.6rem;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  border: 1px solid transparent;
+  transition: transform 200ms ease, box-shadow 200ms ease, border 200ms ease, background 200ms ease;
+  text-align: center;
+.btn {
+  background: linear-gradient(135deg, rgba(127, 209, 255, 0.22), rgba(91, 142, 255, 0.18));
+  border-color: rgba(127, 209, 255, 0.35);
+  color: var(--text);
+}
+
+.button--primary,
+.btn.btn-primary,
+.btn:not(.btn-secondary):not(.btn-ghost) {
+  background: linear-gradient(135deg, #7fd1ff, #5b8eff);
+  color: #031028;
+  box-shadow: 0 18px 48px rgba(91, 142, 255, 0.35);
+}
+
+.button--primary:hover,
+.button--primary:focus-visible,
+.btn.btn-primary:hover,
+.btn.btn-primary:focus-visible,
+.btn:not(.btn-secondary):not(.btn-ghost):hover,
+.btn:not(.btn-secondary):not(.btn-ghost):focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 55px rgba(91, 142, 255, 0.45);
+}
+
+.button--outline,
+.btn.btn-secondary,
+.btn-secondary {
+  border-color: rgba(127, 209, 255, 0.4);
+  background: rgba(8, 18, 36, 0.5);
+  color: var(--text);
+}
+
+.button--outline:hover,
+.button--outline:focus-visible,
+.btn.btn-secondary:hover,
+.btn.btn-secondary:focus-visible,
+.btn-secondary:hover,
+.btn-secondary:focus-visible {
+  border-color: rgba(127, 209, 255, 0.8);
+  background: rgba(8, 18, 36, 0.75);
+  transform: translateY(-1px);
+}
+
+.hero-metrics {
+  height: 100%;
+  display: grid;
+  gap: 1.35rem;
+}
+
+.metric-card {
+  border-radius: var(--radius-xl);
+  padding: clamp(1.6rem, 3vw, 2.3rem);
+  border: 1px solid rgba(127, 209, 255, 0.2);
+  background: linear-gradient(150deg, rgba(8, 18, 36, 0.8), rgba(29, 52, 92, 0.6));
+  box-shadow: var(--shadow-soft);
+}
+
+.metric-card__title {
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.25em;
+  color: var(--text-faint);
+}
+
+.metric-card__grid {
+  margin-top: 1.6rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.metric-card__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid rgba(127, 209, 255, 0.18);
+}
+
+.metric-card__item:last-child {
+  border-bottom: 0;
+  padding-bottom: 0;
+}
+
+.metric-card__value {
+  font-size: 2rem;
+  font-weight: 600;
+  color: var(--accent-strong);
+}
+
+.metric-card__context {
+  border-radius: var(--radius-lg);
+  padding: clamp(1.4rem, 3vw, 2rem);
+  background: rgba(255, 147, 79, 0.08);
+  border: 1px solid rgba(255, 147, 79, 0.32);
+  color: rgba(255, 211, 102, 0.92);
+  font-size: 0.95rem;
+}
+
+.section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.section-header__title {
+  font-size: clamp(2rem, 2.6vw, 2.8rem);
+  font-weight: 650;
+  letter-spacing: -0.015em;
+}
+
+.section-header__description {
+  font-size: 1rem;
+  color: var(--text-soft);
+  max-width: 60ch;
+}
+
+.card-grid {
+  margin-top: clamp(2rem, 3vw, 3rem);
+  display: grid;
+  gap: clamp(1.5rem, 2.8vw, 2.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(270px, 1fr));
+}
+
+.grid.cards {
+  display: grid;
+  gap: 1.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  height: 100%;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(127, 209, 255, 0.2);
+  background: rgba(8, 16, 32, 0.78);
+  padding: clamp(1.5rem, 2.4vw, 2rem);
+  box-shadow: var(--shadow-soft);
+  transition: transform 220ms ease, box-shadow 220ms ease, border 220ms ease;
+}
+
+.card:hover,
+.card:focus-within {
+  transform: translateY(-4px);
+  border-color: rgba(127, 209, 255, 0.45);
+  box-shadow: 0 28px 70px rgba(91, 142, 255, 0.3);
+}
+
+.card__media {
+  aspect-ratio: 16 / 10;
+  overflow: hidden;
+  border-radius: var(--radius-md);
+}
+
+.card__title {
+  font-size: 1.35rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.card__subtitle {
+  color: var(--text-soft);
+  font-size: 0.95rem;
+}
+
+.card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--text-faint);
+}
+
+.card__cta {
+  margin-top: auto;
+}
+
+.card__cta .button {
+  width: 100%;
+}
+
+.card--highlight {
+  background: linear-gradient(160deg, rgba(11, 38, 66, 0.85), rgba(56, 91, 140, 0.75));
+}
+
+.card--neutral {
+  background: rgba(8, 18, 38, 0.78);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(127, 209, 255, 0.3);
+  background: rgba(127, 209, 255, 0.12);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.badge-gender--inline {
+  margin-top: 0.5rem;
+}
+
+.badge-gender[data-sex="male"] {
+  border-color: rgba(127, 209, 255, 0.45);
+  background: rgba(127, 209, 255, 0.2);
+  color: var(--accent-strong);
+}
+
+.badge-gender[data-sex="female"] {
+  border-color: rgba(255, 147, 79, 0.45);
+  background: rgba(255, 147, 79, 0.2);
+  color: #ffcd8b;
+}
+
+.badge-gender[data-sex="unknown"] {
+  border-color: rgba(215, 225, 247, 0.4);
+  background: rgba(215, 225, 247, 0.16);
+  color: var(--text-soft);
+}
+
+.badge-pattern {
+  background: rgba(255, 211, 102, 0.18);
+  border-color: rgba(255, 211, 102, 0.4);
+  color: #ffe8a6;
+}
+
+.animal-marker {
+  margin-left: 0.35rem;
+  color: var(--accent-warm);
+}
+
+.rich-text-content,
+.content-prose {
+  color: var(--text-soft);
+  font-size: 1rem;
+  display: grid;
+  gap: 1.1rem;
+}
+
+.rich-text-content h2,
+.content-prose h2 {
+  font-size: 1.8rem;
+  font-weight: 600;
+  color: var(--text);
+  margin-top: 2.4rem;
+}
+
+.rich-text-content h3,
+.content-prose h3 {
+  font-size: 1.35rem;
+  font-weight: 600;
+  margin-top: 2rem;
+}
+
+.rich-text-content ul,
+.rich-text-content ol,
+.content-prose ul,
+.content-prose ol {
+  padding-left: 1.4rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.section--stripe {
+  background: rgba(5, 12, 28, 0.75);
+  border-block: 1px solid rgba(127, 209, 255, 0.15);
+}
+
+.highlight-deck {
+  display: grid;
+  gap: clamp(1.8rem, 3vw, 2.8rem);
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.highlight-card {
+  border-radius: var(--radius-lg);
+  padding: clamp(1.6rem, 2.5vw, 2.2rem);
+  background: rgba(12, 24, 48, 0.8);
+  border: 1px solid rgba(127, 209, 255, 0.24);
+  box-shadow: var(--shadow-soft);
+}
+
+.highlight-card strong {
+  display: block;
+  font-size: 1.6rem;
+  margin-bottom: 0.5rem;
+}
+
+.highlight-card ol {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.trust-grid {
+  display: grid;
+  gap: clamp(1.2rem, 2vw, 2.2rem);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.trust-card {
+  border-radius: var(--radius-md);
+  padding: clamp(1.4rem, 2vw, 1.9rem);
+  background: rgba(7, 16, 34, 0.78);
+  border: 1px solid rgba(127, 209, 255, 0.25);
+}
+
+.trust-card h3 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.listing-grid {
+  display: grid;
+  gap: clamp(1.6rem, 2.8vw, 2.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.listing-card {
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(127, 209, 255, 0.2);
+  background: rgba(9, 18, 34, 0.78);
+  padding: clamp(1.8rem, 2.5vw, 2.3rem);
+  display: grid;
+  gap: 1rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.listing-card__meta {
+  display: grid;
+  gap: 0.4rem;
+  font-size: 0.95rem;
+  color: var(--text-soft);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.listing-card__cta {
+  margin-top: 0.5rem;
+}
+
+.breadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: var(--text-faint);
+}
+
+.breadcrumb a {
+  color: var(--text-soft);
+}
+
+.article-shell {
+  border-radius: var(--radius-xl);
+  padding: clamp(2.4rem, 3vw, 3.4rem);
+  background: rgba(8, 18, 38, 0.8);
+  border: 1px solid rgba(127, 209, 255, 0.25);
+  box-shadow: var(--shadow-soft);
+}
+
+.article-shell header {
+  display: grid;
+  gap: 1rem;
+}
+
+.article-shell time {
   font-size: 0.9rem;
+  letter-spacing: 0.18em;
+  color: var(--text-faint);
+  text-transform: uppercase;
 }
 
-.alert-success {
-  background: rgba(52, 211, 153, 0.16);
-  border: 1px solid rgba(52, 211, 153, 0.35);
-  color: #bbf7d0;
+.article-shell h1 {
+  font-size: clamp(2.4rem, 3vw, 3.1rem);
+  margin: 0;
 }
 
-.alert-error {
-  background: rgba(248, 113, 113, 0.16);
-  border: 1px solid var(--danger-border);
-  color: #fecaca;
+.article-shell figure {
+  margin: 2rem 0;
+}
+
+.article-shell figure img {
+  border-radius: var(--radius-lg);
+}
+
+.table-responsive {
+  width: 100%;
+  overflow-x: auto;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(127, 209, 255, 0.22);
+  background: rgba(5, 15, 32, 0.78);
+  box-shadow: var(--shadow-soft);
 }
 
 .table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.9rem;
   color: var(--text);
 }
 
 .table thead {
-  background: rgba(15, 23, 42, 0.85);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-size: 0.75rem;
-  color: var(--text-muted);
+  background: rgba(127, 209, 255, 0.12);
 }
 
 .table th,
 .table td {
-  padding: 0.75rem;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
-  vertical-align: top;
+  text-align: left;
+  padding: 1rem 1.2rem;
+  border-bottom: 1px solid rgba(127, 209, 255, 0.12);
 }
 
-.table tbody tr:hover {
-  background: rgba(34, 211, 238, 0.06);
+.form-grid {
+  display: grid;
+  gap: 1.5rem;
 }
 
-form label {
-  display: block;
+.form-row {
+  display: grid;
+  gap: 1.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
   font-weight: 500;
-  color: var(--text);
-  margin-top: 1rem;
+  color: var(--text-soft);
 }
 
-form label:first-of-type {
-  margin-top: 0;
-}
-
-form input[type="text"],
-form input[type="email"],
-form input[type="number"],
-form input[type="password"],
-form input[type="file"],
-form select,
-form textarea {
+.input,
+.textarea,
+.select {
+  appearance: none;
   width: 100%;
-  margin-top: 0.5rem;
-  padding: 0.65rem 0.85rem;
-  border-radius: 0.85rem;
-  border: 1px solid var(--border);
-  background: var(--surface-soft);
+  padding: 0.95rem 1.2rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(127, 209, 255, 0.35);
+  background: rgba(8, 18, 36, 0.6);
   color: var(--text);
   font: inherit;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  transition: border 200ms ease, background 200ms ease;
 }
 
-form textarea {
-  min-height: 140px;
+.input:focus,
+.textarea:focus,
+.select:focus {
+  border-color: rgba(127, 209, 255, 0.75);
+  background: rgba(8, 18, 36, 0.85);
+}
+
+.textarea {
+  min-height: 180px;
   resize: vertical;
 }
 
-form select {
-  appearance: none;
-}
-
-form input:focus,
-form select:focus,
-form textarea:focus {
-  outline: none;
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px rgba(34, 211, 238, 0.18);
-}
-
-form button[type="submit"],
-form button[type="button"] {
-  margin-top: 1.25rem;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.35rem;
-  padding: 0.55rem 1.4rem;
-  border-radius: 999px;
-  border: 1px solid var(--border-strong);
-  background: rgba(34, 211, 238, 0.18);
-  color: var(--accent);
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  transition: all 0.2s ease;
-}
-
-form button[type="submit"]:hover,
-form button[type="button"]:hover {
-  border-color: var(--accent);
-  background: rgba(34, 211, 238, 0.28);
-  box-shadow: 0 12px 30px rgba(6, 182, 212, 0.25);
-}
-
-input[type="checkbox"] {
-  width: 1.1rem;
-  height: 1.1rem;
-  border-radius: 0.35rem;
-  border: 1px solid var(--border);
-  background: var(--surface-soft);
-  accent-color: var(--accent);
-}
-
-.nav-dropdown {
-  position: absolute;
-  top: calc(100% + 0.5rem);
-  left: 0;
-  min-width: 14rem;
-  padding: 0.75rem;
-  border-radius: 1rem;
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  background: rgba(2, 6, 23, 0.95);
-  box-shadow: 0 24px 60px rgba(8, 47, 73, 0.4);
-  display: none;
-  flex-direction: column;
-  gap: 0.35rem;
-  z-index: 40;
-}
-
-[data-nav-group]:hover .nav-dropdown,
-[data-nav-group]:focus-within .nav-dropdown,
-.nav-dropdown.open {
-  display: flex;
-}
-
-.nav-dropdown a {
+.rich-text {
+  min-height: 200px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(127, 209, 255, 0.3);
+  background: rgba(8, 18, 36, 0.6);
   color: var(--text);
-}
-
-.nav-dropdown a:hover {
-  color: var(--accent);
-}
-
-.rich-text-wrapper {
-  margin-top: 0.75rem;
-  border: 1px solid var(--border);
-  border-radius: 1rem;
-  overflow: hidden;
-  background: var(--surface-soft);
-}
-
-.rich-text-toolbar {
-  display: flex;
-  gap: 0.35rem;
-  padding: 0.5rem;
-  background: rgba(148, 163, 184, 0.15);
-  border-bottom: 1px solid var(--border);
-}
-
-.rich-text-btn {
-  border: 1px solid var(--border);
-  border-radius: 0.65rem;
-  background: rgba(15, 23, 42, 0.7);
-  color: var(--text);
-  font-size: 0.85rem;
-  padding: 0.35rem 0.6rem;
-  cursor: pointer;
-  transition: all 0.2s ease;
-}
-
-.rich-text-btn:hover,
-.rich-text-btn:focus {
-  border-color: var(--accent);
-  color: var(--accent);
-}
-
-.rich-text-editor {
-  min-height: 180px;
-  padding: 1rem;
-  background: rgba(2, 6, 23, 0.7);
-  outline: none;
-  color: var(--text);
-  font-size: 0.95rem;
+  padding: 0.85rem 1rem;
   line-height: 1.6;
 }
 
-.rich-text-editor:focus {
-  box-shadow: inset 0 0 0 2px rgba(34, 211, 238, 0.25);
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
 }
 
-.rich-text-content {
+.alert {
+  border-radius: var(--radius-md);
+  padding: 1rem 1.2rem;
+  border: 1px solid rgba(255, 147, 79, 0.4);
+  background: rgba(255, 147, 79, 0.12);
+  color: #ffcead;
+}
+
+.alert-error {
+  border-color: rgba(255, 107, 107, 0.55);
+  background: rgba(255, 107, 107, 0.18);
+  color: #ffd7d7;
+}
+
+.alert-success {
+  border-color: rgba(107, 255, 207, 0.55);
+  background: rgba(107, 255, 207, 0.16);
+  color: #d8fff2;
+}
+
+.site-footer {
+  margin-top: auto;
+  padding: clamp(2rem, 4vw, 3.6rem) clamp(1.5rem, 5vw, 6rem);
+  background: rgba(3, 8, 18, 0.95);
+  border-top: 1px solid rgba(127, 209, 255, 0.18);
+}
+
+.site-footer__inner {
+  margin: 0 auto;
+  width: var(--content-max);
+  display: grid;
+  gap: 1.4rem;
+  font-size: 0.95rem;
+  color: var(--text-soft);
+}
+
+.site-footer__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  color: var(--text-faint);
+  font-size: 0.85rem;
+}
+
+/* Admin */
+
+.admin-layout {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2rem, 3vw, 3rem);
+  padding: clamp(3rem, 6vw, 4rem) clamp(1.5rem, 5vw, 3.5rem);
+  width: 100%;
+  max-width: none;
+}
+
+.admin-shell {
+  width: 100%;
+  border-radius: var(--radius-xl);
+  padding: clamp(2.2rem, 3vw, 3.2rem);
+  border: 1px solid rgba(127, 209, 255, 0.25);
+  background: rgba(8, 18, 38, 0.82);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: clamp(1.8rem, 3vw, 2.6rem);
+}
+
+.admin-page-header {
+  display: grid;
+  gap: 0.75rem;
+  align-items: start;
+}
+
+.admin-page-header .admin-title {
+  margin: 0;
+  font-size: clamp(2.2rem, 3vw, 2.9rem);
+  font-weight: 650;
+}
+
+.admin-page-header .admin-subtitle {
+  color: var(--text-soft);
+  max-width: 70ch;
+}
+
+.admin-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+}
+
+.admin-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.admin-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.55rem 1.2rem;
+  border-radius: 999px;
+  border: 1px solid rgba(127, 209, 255, 0.28);
+  background: rgba(8, 18, 36, 0.6);
+  color: var(--text-soft);
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.admin-chip:hover,
+.admin-chip:focus-visible {
+  border-color: rgba(127, 209, 255, 0.6);
   color: var(--text);
-  line-height: 1.7;
 }
 
-.rich-text-content p {
-  margin-bottom: 1rem;
+.admin-chip.is-active {
+  border-color: transparent;
+  background: linear-gradient(135deg, #7fd1ff, #5b8eff);
+  color: #031028;
+  box-shadow: 0 16px 40px rgba(91, 142, 255, 0.35);
 }
 
-.rich-text-content ul,
-.rich-text-content ol {
-  margin: 0 0 1rem 1.5rem;
+.table-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
 }
 
-.rich-text-content table {
+.admin-toolbar {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  align-items: end;
+}
+
+.admin-divider {
+  height: 1px;
+  width: 100%;
+  background: linear-gradient(90deg, transparent, rgba(127, 209, 255, 0.6), transparent);
+  border: none;
+}
+
+.admin-shell form {
+  display: grid;
+  gap: 1rem;
+}
+
+.admin-shell form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-weight: 500;
+  color: var(--text-soft);
+}
+
+.admin-shell form input[type="text"],
+.admin-shell form input[type="email"],
+.admin-shell form input[type="number"],
+.admin-shell form input[type="file"],
+.admin-shell form select,
+.admin-shell form textarea {
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(127, 209, 255, 0.3);
+  background: rgba(8, 18, 36, 0.6);
+  padding: 0.85rem 1rem;
+  color: var(--text);
+  font: inherit;
+  transition: border 200ms ease, background 200ms ease;
+}
+
+.admin-shell form input[type="file"] {
+  padding: 0.6rem;
+  background: transparent;
+}
+
+.admin-shell form input:focus,
+.admin-shell form select:focus,
+.admin-shell form textarea:focus {
+  border-color: rgba(127, 209, 255, 0.8);
+  background: rgba(8, 18, 36, 0.8);
+}
+
+.admin-shell form button[type="submit"],
+.admin-shell form .btn,
+.admin-shell form .button {
+  justify-self: start;
+}
+
+.form-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.9rem;
+  color: var(--text-soft);
+}
+
+.form-switch input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  border-radius: 5px;
+  border: 1px solid rgba(127, 209, 255, 0.3);
+  background: rgba(6, 14, 26, 0.6);
+}
+
+.admin-table {
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  border: 1px solid rgba(127, 209, 255, 0.25);
+}
+
+.admin-table table {
   width: 100%;
   border-collapse: collapse;
-  margin-bottom: 1.5rem;
-  font-size: 0.95rem;
 }
 
-.rich-text-content table th,
-.rich-text-content table td {
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  padding: 0.5rem 0.75rem;
+.admin-table th,
+.admin-table td {
+  padding: 1rem 1.3rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(127, 209, 255, 0.16);
 }
+
+.admin-table thead {
+  background: rgba(127, 209, 255, 0.12);
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.15em;
+  color: var(--text-faint);
+}
+
+/* Genetics */
 
 .gene-selector {
   display: grid;
-  gap: 1.75rem;
-  border: 1px solid var(--border);
-  border-radius: 1.75rem;
-  background: rgba(2, 6, 23, 0.82);
-  padding: 2rem;
+  gap: 1.5rem;
 }
 
 .gene-selector__header {
   display: grid;
-  gap: 0.35rem;
-}
-
-.gene-selector__header h2 {
-  margin: 0;
-  color: var(--text);
-}
-
-.gene-selector__header p {
-  margin: 0;
-  font-size: 0.95rem;
-  color: var(--text-muted);
+  gap: 0.5rem;
 }
 
 .gene-selector__parents {
   display: grid;
   gap: 1.5rem;
-}
-
-@media (min-width: 900px) {
-  .gene-selector__parents {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
 
 .gene-parent {
-  position: relative;
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  border-radius: 1.5rem;
-  padding: 1.35rem;
-  background: rgba(15, 23, 42, 0.78);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(127, 209, 255, 0.28);
+  background: rgba(8, 18, 38, 0.72);
+  padding: 1.5rem;
   display: grid;
-  gap: 0.9rem;
+  gap: 1rem;
 }
 
 .gene-parent__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.75rem;
-}
-
-.gene-parent__header h3 {
-  margin: 0;
-  font-size: 1.05rem;
-  color: var(--text);
+  gap: 1rem;
 }
 
 .gene-parent__clear {
-  margin: 0;
-  padding: 0.25rem 0.85rem;
+  font-size: 0.85rem;
   border-radius: 999px;
-  border: 1px solid rgba(34, 211, 238, 0.25);
-  background: rgba(34, 211, 238, 0.12);
-  color: var(--accent);
-  font-size: 0.75rem;
-  font-weight: 600;
-  text-transform: none;
-  letter-spacing: 0.02em;
-  cursor: pointer;
-  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.gene-parent__clear:hover {
-  border-color: var(--accent);
-  background: rgba(34, 211, 238, 0.24);
+  padding: 0.35rem 0.9rem;
+  border: 1px solid rgba(127, 209, 255, 0.35);
+  background: rgba(127, 209, 255, 0.12);
   color: var(--text);
 }
 
+.gene-parent__clear:hover,
+.gene-parent__clear:focus-visible {
+  border-color: rgba(127, 209, 255, 0.65);
+  background: rgba(127, 209, 255, 0.22);
+}
+
 .gene-multiselect {
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  border-radius: 1.25rem;
-  padding: 0.6rem 0.75rem;
-  background: rgba(15, 23, 42, 0.65);
-  display: flex;
-  align-items: center;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(127, 209, 255, 0.3);
+  background: rgba(6, 14, 28, 0.7);
+  padding: 0.5rem;
 }
 
 .gene-multiselect__body {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
   gap: 0.5rem;
-  width: 100%;
+  align-items: center;
 }
 
 .gene-multiselect__tags {
   display: flex;
   flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.gene-multiselect__tags::before {
+  content: attr(data-placeholder);
+  color: var(--text-faint);
+  font-size: 0.85rem;
+  display: var(--placeholder-display, inline);
+}
+
+.gene-multiselect__tags[data-placeholder='']::before {
+  display: none;
+}
+
+.gene-multiselect__tags [data-tag] {
+  display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  flex: 1;
-  min-height: 1.5rem;
+  gap: 0.35rem;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(127, 209, 255, 0.18);
+  border: 1px solid rgba(127, 209, 255, 0.35);
+  font-size: 0.85rem;
 }
 
-.gene-multiselect__placeholder {
-  color: var(--text-muted);
-  font-size: 0.9rem;
-}
-
-.gene-multiselect input[type="text"] {
+.gene-multiselect__tags button {
   border: none;
   background: transparent;
-  margin: 0;
-  padding: 0;
-  flex: 1 0 160px;
-  min-width: 140px;
-  font: inherit;
+  color: var(--text-faint);
+}
+
+.gene-multiselect__body input {
+  min-width: 120px;
+  flex: 1 1 160px;
+  border: none;
+  background: transparent;
   color: var(--text);
-}
-
-.gene-multiselect input[type="text"]:focus {
-  outline: none;
-}
-
-.gene-parent__hint {
-  margin: 0;
-  font-size: 0.85rem;
-  color: var(--text-muted);
+  padding: 0.35rem;
 }
 
 .gene-parent__suggestions {
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(127, 209, 255, 0.3);
+  background: rgba(5, 12, 26, 0.92);
+  padding: 0.5rem;
   display: grid;
-  gap: 0.45rem;
-  padding: 0.75rem;
-  border-radius: 1rem;
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  background: rgba(2, 6, 23, 0.96);
-  box-shadow: 0 24px 48px rgba(8, 47, 73, 0.45);
+  gap: 0.4rem;
   max-height: 220px;
   overflow-y: auto;
 }
 
-.gene-suggestion {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 1rem;
-  border: 1px solid rgba(148, 163, 184, 0.28);
-  background: rgba(15, 23, 42, 0.8);
-  border-radius: 0.85rem;
-  padding: 0.55rem 0.85rem;
-  color: var(--text);
-  cursor: pointer;
-  transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
-  text-transform: none;
-  letter-spacing: 0;
-  margin: 0;
+.gene-parent__suggestions button {
+  border-radius: var(--radius-sm);
+  padding: 0.5rem 0.65rem;
+  text-align: left;
 }
 
-.gene-suggestion strong {
-  font-size: 0.9rem;
-  font-weight: 600;
-  color: var(--text);
+.gene-parent__suggestions button:hover,
+.gene-parent__suggestions button:focus-visible {
+  background: rgba(127, 209, 255, 0.18);
 }
 
-.gene-suggestion span {
-  font-size: 0.8rem;
-  color: var(--text-muted);
-}
-
-.gene-suggestion:hover {
-  border-color: var(--accent);
-  background: rgba(34, 211, 238, 0.14);
-  transform: translateY(-1px);
-}
-
-.gene-suggestion--empty {
-  border: 1px dashed rgba(148, 163, 184, 0.3);
-  background: transparent;
-  justify-content: center;
-  color: var(--text-muted);
-}
-
-.gene-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.38rem 0.75rem;
-  border-radius: 999px;
-  border: 1px solid rgba(34, 211, 238, 0.35);
-  background: rgba(34, 211, 238, 0.18);
-  color: var(--accent);
-  font-size: 0.8rem;
-  font-weight: 600;
-}
-
-.gene-chip__label {
-  pointer-events: none;
-}
-
-.gene-chip__remove {
-  border: none;
-  background: transparent;
-  color: inherit;
+.gene-parent__hint {
   font-size: 0.85rem;
-  cursor: pointer;
-  line-height: 1;
-  padding: 0;
-  margin: 0;
-  text-transform: none;
-  letter-spacing: 0;
-}
-
-.gene-chip__remove:hover {
-  color: var(--text);
+  color: var(--text-faint);
 }
 
 .gene-selector__actions {
   display: flex;
-  gap: 0.75rem;
   flex-wrap: wrap;
+  gap: 0.75rem;
 }
 
-.gene-selector__actions .btn,
-.gene-selector__actions .btn-secondary {
-  margin-top: 0;
-}
-
-.plan-entry {
-  border: 1px solid var(--border);
-  border-radius: 1.25rem;
-  background: rgba(2, 6, 23, 0.75);
-  padding: 1.25rem;
+.gene-reference {
   display: grid;
+  gap: 1.8rem;
+  margin-top: 2rem;
+}
+
+.gene-reference__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 1rem;
 }
 
-.plan-entry__header {
+.gene-reference__states {
+  display: grid;
+  gap: 0.6rem;
+  margin: 1rem 0;
+}
+
+.gene-reference__states div {
   display: flex;
   justify-content: space-between;
   gap: 1rem;
-  align-items: center;
-}
-
-.plan-entry__actions {
-  display: flex;
-  gap: 0.5rem;
-}
-
-.plan-entry__section {
-  border-top: 1px solid rgba(148, 163, 184, 0.18);
-  padding-top: 1rem;
+  font-size: 0.9rem;
+  color: var(--text-soft);
 }
 
 .gene-results {
   margin-top: 2.5rem;
-}
-
-.gene-results__card {
-  padding: 0;
-  overflow: hidden;
 }
 
 .gene-results__table {
@@ -644,121 +1329,101 @@ input[type="checkbox"] {
   color: var(--text);
 }
 
-.gene-results__table thead th {
+.gene-results__table th,
+.gene-results__table td {
+  padding: 0.9rem 1rem;
+  border-bottom: 1px solid rgba(127, 209, 255, 0.15);
+  text-align: left;
+}
+
+.gene-results__table thead {
+  background: rgba(127, 209, 255, 0.16);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
   font-size: 0.75rem;
-  color: var(--text-muted);
-  padding: 1rem 1.25rem;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
-}
-
-.gene-results__table tbody td {
-  padding: 1.1rem 1.25rem;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
-  vertical-align: top;
-}
-
-.gene-results__table tbody tr:last-child td {
-  border-bottom: none;
+  letter-spacing: 0.12em;
 }
 
 .gene-results__fraction {
-  display: block;
   font-weight: 600;
-  font-size: 1rem;
-  color: var(--text);
+  color: var(--accent-strong);
 }
 
 .gene-results__percentage {
   display: block;
-  margin-top: 0.2rem;
   font-size: 0.8rem;
-  color: var(--text-muted);
+  color: var(--text-faint);
 }
 
 .gene-results__tags {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.4rem;
-}
-
-.gene-results__placeholder {
-  color: var(--text-muted);
-  font-size: 0.85rem;
-}
-
-.gene-results__morph {
-  font-weight: 600;
-  color: var(--text);
-}
-
-.gene-results__empty {
-  padding: 2.5rem;
-  text-align: center;
-}
-
-.gene-results__empty h3 {
-  margin: 0 0 0.5rem;
-  color: var(--text);
-}
-
-.gene-results__empty p {
-  margin: 0;
-  color: var(--text-muted);
+  gap: 0.45rem;
 }
 
 .gene-pill {
   display: inline-flex;
   align-items: center;
-  gap: 0.3rem;
+  padding: 0.35rem 0.75rem;
   border-radius: 999px;
-  padding: 0.3rem 0.65rem;
-  font-size: 0.72rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
+  font-size: 0.8rem;
+  letter-spacing: 0.05em;
 }
 
 .gene-pill--visual {
-  background: rgba(250, 204, 21, 0.22);
-  color: #facc15;
+  background: rgba(127, 209, 255, 0.18);
+  border: 1px solid rgba(127, 209, 255, 0.35);
 }
 
 .gene-pill--carrier {
-  background: rgba(34, 211, 238, 0.22);
-  color: var(--accent);
+  background: rgba(255, 211, 102, 0.18);
+  border: 1px solid rgba(255, 211, 102, 0.35);
 }
 
-.gene-pill--normal {
-  background: rgba(148, 163, 184, 0.18);
-  color: var(--text-muted);
+.gene-results__placeholder {
+  color: var(--text-faint);
+  font-size: 0.9rem;
 }
 
-.plan-parents {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 0.75rem;
+.gene-results__morph {
+  font-weight: 600;
 }
 
-.plan-parents li {
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  border-radius: 1rem;
-  padding: 0.75rem 1rem;
-  background: rgba(15, 23, 42, 0.7);
+.gene-results__empty {
+  padding: 1.5rem;
+  text-align: center;
+  color: var(--text-faint);
 }
 
-.plan-parent__title {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
+@media (max-width: 860px) {
+  .hero-panel,
+  .metric-card {
+    border-radius: var(--radius-lg);
+  }
+
+  .site-header__bar {
+    padding-inline: clamp(1.2rem, 5vw, 2rem);
+  }
+
+  .section {
+    padding-inline: clamp(1rem, 5vw, 2rem);
+  }
 }
 
-@media (min-width: 1024px) {
-  .gene-selector__parents {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+@media (max-width: 640px) {
+  .hero-panel__title {
+    font-size: clamp(2.2rem, 8vw, 3rem);
+  }
+
+  .hero-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .button {
+    width: 100%;
+  }
+
+  .site-footer__inner {
+    font-size: 0.9rem;
   }
 }

--- a/public/assets/style.css
+++ b/public/assets/style.css
@@ -1,108 +1,40 @@
 :root {
-  --bg: #0f172a;
-  --surface: rgba(15, 23, 42, 0.85);
-  --surface-light: rgba(148, 163, 184, 0.15);
+  --surface: rgba(15, 23, 42, 0.78);
+  --surface-soft: rgba(15, 23, 42, 0.58);
+  --surface-strong: rgba(15, 23, 42, 0.92);
+  --border: rgba(148, 163, 184, 0.25);
+  --border-strong: rgba(34, 211, 238, 0.45);
   --accent: #22d3ee;
-  --accent-strong: #14b8a6;
+  --accent-strong: #06b6d4;
   --text: #e2e8f0;
   --text-muted: #94a3b8;
-  --card-border: rgba(148, 163, 184, 0.35);
-  --success: #4ade80;
-  --danger: #f87171;
+  --success: #34d399;
+  --danger: #fb7185;
+  --danger-border: rgba(248, 113, 113, 0.35);
 }
 
-* {
-  box-sizing: border-box;
-}
-
-body {
-  margin: 0;
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background: linear-gradient(160deg, #0f172a, #0b1120 45%, #082f49 100%);
+main h1 {
+  font-size: clamp(2rem, 2.8vw, 3.2rem);
+  font-weight: 600;
   color: var(--text);
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
+  margin-bottom: 1.5rem;
 }
 
-a {
-  color: var(--accent);
-  text-decoration: none;
-}
-
-a:hover {
-  color: var(--accent-strong);
-}
-
-.text-muted {
-  color: var(--text-muted);
-}
-
-header {
-  backdrop-filter: blur(16px);
-  background: rgba(15, 23, 42, 0.7);
-  border-bottom: 1px solid var(--card-border);
-  position: sticky;
-  top: 0;
-  z-index: 10;
-}
-
-.wrapper {
-  width: min(1200px, 92vw);
-  margin: 0 auto;
-}
-
-.navbar {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1rem 0;
-}
-
-.nav-links {
-  display: flex;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-
-.nav-links a {
-  padding: 0.5rem 0.9rem;
-  border-radius: 999px;
-  background: var(--surface-light);
+main h2 {
+  font-size: clamp(1.4rem, 2vw, 2rem);
+  font-weight: 600;
   color: var(--text);
-  font-size: 0.95rem;
-  transition: background 0.2s ease, transform 0.2s ease;
+  margin: 1.5rem 0 0.75rem;
 }
 
-.nav-links a.active,
-.nav-links a:hover {
-  background: var(--accent-strong);
-  color: #04101f;
-  transform: translateY(-2px);
+main h3 {
+  font-size: clamp(1.15rem, 1.6vw, 1.5rem);
+  font-weight: 600;
+  color: var(--text);
+  margin: 1.25rem 0 0.5rem;
 }
 
-main {
-  flex: 1;
-  padding: 3rem 0 5rem;
-}
-
-.hero {
-  display: grid;
-  gap: 2rem;
-  padding: 3rem;
-  background: linear-gradient(140deg, rgba(6, 182, 212, 0.18), rgba(8, 47, 73, 0.9));
-  border-radius: 28px;
-  border: 1px solid var(--card-border);
-  box-shadow: 0 30px 80px rgba(2, 6, 23, 0.45);
-}
-
-.hero h1 {
-  font-size: clamp(2.6rem, 4vw, 3.4rem);
-  margin: 0;
-}
-
-.hero p {
-  font-size: 1.1rem;
+main p {
   color: var(--text-muted);
   line-height: 1.6;
 }
@@ -118,163 +50,715 @@ main {
 
 .card {
   background: var(--surface);
-  border-radius: 22px;
-  border: 1px solid var(--card-border);
+  border: 1px solid var(--border);
+  border-radius: 1.5rem;
   padding: 1.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  box-shadow: 0 20px 60px rgba(8, 47, 73, 0.35);
+  box-shadow: 0 18px 45px rgba(8, 47, 73, 0.35);
+  color: var(--text);
 }
 
-.card img {
-  width: 100%;
-  height: 180px;
-  object-fit: cover;
-  border-radius: 18px;
-  border: 1px solid var(--card-border);
+.card > h2,
+.card > h3 {
+  margin-top: 0;
+}
+
+.stack {
+  display: grid;
+  gap: 1.25rem;
 }
 
 .badge {
-  align-self: flex-start;
-  padding: 0.35rem 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   border-radius: 999px;
-  font-size: 0.75rem;
-  background: rgba(34, 211, 238, 0.2);
+  padding: 0.25rem 0.75rem;
+  background: rgba(34, 211, 238, 0.16);
   color: var(--accent);
-  text-transform: uppercase;
+  font-size: 0.7rem;
+  font-weight: 600;
   letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.badge-pattern {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.85), rgba(148, 163, 184, 0.3));
+  color: #0f172a;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.animal-marker {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 0.35rem;
+  font-size: 0.85rem;
+  color: var(--accent);
+}
+
+.btn,
+.card a.btn,
+.card a.btn-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  border-radius: 999px;
+  padding: 0.55rem 1.2rem;
+  font-weight: 600;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  transition: all 0.2s ease;
+  border: 1px solid var(--border-strong);
+  background: rgba(34, 211, 238, 0.15);
+  color: var(--accent);
+}
+
+.btn-secondary {
+  border-color: rgba(148, 163, 184, 0.35);
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--text);
+}
+
+.btn:hover,
+.btn-secondary:hover {
+  border-color: var(--accent);
+  background: rgba(34, 211, 238, 0.22);
+  color: var(--text);
+  box-shadow: 0 12px 30px rgba(6, 182, 212, 0.25);
+  transform: translateY(-1px);
+}
+
+.alert {
+  border-radius: 1rem;
+  padding: 0.75rem 1rem;
+  font-size: 0.9rem;
+}
+
+.alert-success {
+  background: rgba(52, 211, 153, 0.16);
+  border: 1px solid rgba(52, 211, 153, 0.35);
+  color: #bbf7d0;
+}
+
+.alert-error {
+  background: rgba(248, 113, 113, 0.16);
+  border: 1px solid var(--danger-border);
+  color: #fecaca;
 }
 
 .table {
   width: 100%;
   border-collapse: collapse;
-  background: var(--surface);
-  border-radius: 18px;
-  overflow: hidden;
-  border: 1px solid var(--card-border);
+  font-size: 0.9rem;
+  color: var(--text);
+}
+
+.table thead {
+  background: rgba(15, 23, 42, 0.85);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--text-muted);
 }
 
 .table th,
 .table td {
-  padding: 0.85rem 1rem;
-  text-align: left;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
-}
-
-.table th {
-  font-size: 0.9rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--text-muted);
+  padding: 0.75rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  vertical-align: top;
 }
 
 .table tbody tr:hover {
-  background: rgba(15, 118, 110, 0.15);
+  background: rgba(34, 211, 238, 0.06);
 }
 
-form {
+form label {
+  display: block;
+  font-weight: 500;
+  color: var(--text);
+  margin-top: 1rem;
+}
+
+form label:first-of-type {
+  margin-top: 0;
+}
+
+form input[type="text"],
+form input[type="email"],
+form input[type="number"],
+form input[type="password"],
+form input[type="file"],
+form select,
+form textarea {
+  width: 100%;
+  margin-top: 0.5rem;
+  padding: 0.65rem 0.85rem;
+  border-radius: 0.85rem;
+  border: 1px solid var(--border);
+  background: var(--surface-soft);
+  color: var(--text);
+  font: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+form textarea {
+  min-height: 140px;
+  resize: vertical;
+}
+
+form select {
+  appearance: none;
+}
+
+form input:focus,
+form select:focus,
+form textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(34, 211, 238, 0.18);
+}
+
+form button[type="submit"],
+form button[type="button"] {
+  margin-top: 1.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.55rem 1.4rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-strong);
+  background: rgba(34, 211, 238, 0.18);
+  color: var(--accent);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  transition: all 0.2s ease;
+}
+
+form button[type="submit"]:hover,
+form button[type="button"]:hover {
+  border-color: var(--accent);
+  background: rgba(34, 211, 238, 0.28);
+  box-shadow: 0 12px 30px rgba(6, 182, 212, 0.25);
+}
+
+input[type="checkbox"] {
+  width: 1.1rem;
+  height: 1.1rem;
+  border-radius: 0.35rem;
+  border: 1px solid var(--border);
+  background: var(--surface-soft);
+  accent-color: var(--accent);
+}
+
+.nav-dropdown {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  left: 0;
+  min-width: 14rem;
+  padding: 0.75rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(2, 6, 23, 0.95);
+  box-shadow: 0 24px 60px rgba(8, 47, 73, 0.4);
+  display: none;
+  flex-direction: column;
+  gap: 0.35rem;
+  z-index: 40;
+}
+
+[data-nav-group]:hover .nav-dropdown,
+[data-nav-group]:focus-within .nav-dropdown,
+.nav-dropdown.open {
+  display: flex;
+}
+
+.nav-dropdown a {
+  color: var(--text);
+}
+
+.nav-dropdown a:hover {
+  color: var(--accent);
+}
+
+.rich-text-wrapper {
+  margin-top: 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  overflow: hidden;
+  background: var(--surface-soft);
+}
+
+.rich-text-toolbar {
+  display: flex;
+  gap: 0.35rem;
+  padding: 0.5rem;
+  background: rgba(148, 163, 184, 0.15);
+  border-bottom: 1px solid var(--border);
+}
+
+.rich-text-btn {
+  border: 1px solid var(--border);
+  border-radius: 0.65rem;
+  background: rgba(15, 23, 42, 0.7);
+  color: var(--text);
+  font-size: 0.85rem;
+  padding: 0.35rem 0.6rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.rich-text-btn:hover,
+.rich-text-btn:focus {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.rich-text-editor {
+  min-height: 180px;
+  padding: 1rem;
+  background: rgba(2, 6, 23, 0.7);
+  outline: none;
+  color: var(--text);
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.rich-text-editor:focus {
+  box-shadow: inset 0 0 0 2px rgba(34, 211, 238, 0.25);
+}
+
+.rich-text-content {
+  color: var(--text);
+  line-height: 1.7;
+}
+
+.rich-text-content p {
+  margin-bottom: 1rem;
+}
+
+.rich-text-content ul,
+.rich-text-content ol {
+  margin: 0 0 1rem 1.5rem;
+}
+
+.rich-text-content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1.5rem;
+  font-size: 0.95rem;
+}
+
+.rich-text-content table th,
+.rich-text-content table td {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  padding: 0.5rem 0.75rem;
+}
+
+.gene-selector {
+  display: grid;
+  gap: 1.75rem;
+  border: 1px solid var(--border);
+  border-radius: 1.75rem;
+  background: rgba(2, 6, 23, 0.82);
+  padding: 2rem;
+}
+
+.gene-selector__header {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.gene-selector__header h2 {
+  margin: 0;
+  color: var(--text);
+}
+
+.gene-selector__header p {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.gene-selector__parents {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 900px) {
+  .gene-selector__parents {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.gene-parent {
+  position: relative;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 1.5rem;
+  padding: 1.35rem;
+  background: rgba(15, 23, 42, 0.78);
+  display: grid;
+  gap: 0.9rem;
+}
+
+.gene-parent__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.gene-parent__header h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: var(--text);
+}
+
+.gene-parent__clear {
+  margin: 0;
+  padding: 0.25rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(34, 211, 238, 0.25);
+  background: rgba(34, 211, 238, 0.12);
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: none;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.gene-parent__clear:hover {
+  border-color: var(--accent);
+  background: rgba(34, 211, 238, 0.24);
+  color: var(--text);
+}
+
+.gene-multiselect {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 1.25rem;
+  padding: 0.6rem 0.75rem;
+  background: rgba(15, 23, 42, 0.65);
+  display: flex;
+  align-items: center;
+}
+
+.gene-multiselect__body {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+}
+
+.gene-multiselect__tags {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1;
+  min-height: 1.5rem;
+}
+
+.gene-multiselect__placeholder {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.gene-multiselect input[type="text"] {
+  border: none;
+  background: transparent;
+  margin: 0;
+  padding: 0;
+  flex: 1 0 160px;
+  min-width: 140px;
+  font: inherit;
+  color: var(--text);
+}
+
+.gene-multiselect input[type="text"]:focus {
+  outline: none;
+}
+
+.gene-parent__hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.gene-parent__suggestions {
+  display: grid;
+  gap: 0.45rem;
+  padding: 0.75rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(2, 6, 23, 0.96);
+  box-shadow: 0 24px 48px rgba(8, 47, 73, 0.45);
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.gene-suggestion {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(15, 23, 42, 0.8);
+  border-radius: 0.85rem;
+  padding: 0.55rem 0.85rem;
+  color: var(--text);
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+  text-transform: none;
+  letter-spacing: 0;
+  margin: 0;
+}
+
+.gene-suggestion strong {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.gene-suggestion span {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.gene-suggestion:hover {
+  border-color: var(--accent);
+  background: rgba(34, 211, 238, 0.14);
+  transform: translateY(-1px);
+}
+
+.gene-suggestion--empty {
+  border: 1px dashed rgba(148, 163, 184, 0.3);
+  background: transparent;
+  justify-content: center;
+  color: var(--text-muted);
+}
+
+.gene-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.38rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(34, 211, 238, 0.35);
+  background: rgba(34, 211, 238, 0.18);
+  color: var(--accent);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.gene-chip__label {
+  pointer-events: none;
+}
+
+.gene-chip__remove {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 0.85rem;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0;
+  margin: 0;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.gene-chip__remove:hover {
+  color: var(--text);
+}
+
+.gene-selector__actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.gene-selector__actions .btn,
+.gene-selector__actions .btn-secondary {
+  margin-top: 0;
+}
+
+.plan-entry {
+  border: 1px solid var(--border);
+  border-radius: 1.25rem;
+  background: rgba(2, 6, 23, 0.75);
+  padding: 1.25rem;
   display: grid;
   gap: 1rem;
 }
 
-input,
-textarea,
-select {
-  width: 100%;
-  padding: 0.75rem 1rem;
-  border-radius: 14px;
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  background: rgba(15, 23, 42, 0.65);
-  color: var(--text);
-  font-size: 1rem;
-}
-
-textarea {
-  min-height: 120px;
-  resize: vertical;
-}
-
-button,
-.btn {
-  padding: 0.75rem 1.5rem;
-  border-radius: 14px;
-  border: none;
-  cursor: pointer;
-  font-weight: 600;
-  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
-  color: #04101f;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-button:hover,
-.btn:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 15px 40px rgba(20, 184, 166, 0.35);
-}
-
-.btn-secondary {
-  background: rgba(148, 163, 184, 0.18);
-  color: var(--text);
-}
-
-.alert {
-  padding: 1rem 1.25rem;
-  border-radius: 16px;
-  border: 1px solid var(--card-border);
-}
-
-.alert-success {
-  background: rgba(34, 197, 94, 0.2);
-  color: var(--success);
-}
-
-.alert-error {
-  background: rgba(239, 68, 68, 0.18);
-  color: var(--danger);
-}
-
-.footer {
-  margin-top: 4rem;
-  padding: 2rem 0;
-  border-top: 1px solid var(--card-border);
-  text-align: center;
-  color: var(--text-muted);
-  font-size: 0.9rem;
-}
-
-.admin-nav {
+.plan-entry__header {
   display: flex;
+  justify-content: space-between;
   gap: 1rem;
-  flex-wrap: wrap;
-  margin-bottom: 2rem;
+  align-items: center;
 }
 
-.admin-nav a {
-  padding: 0.6rem 1.1rem;
-  border-radius: 12px;
-  background: rgba(148, 163, 184, 0.14);
+.plan-entry__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.plan-entry__section {
+  border-top: 1px solid rgba(148, 163, 184, 0.18);
+  padding-top: 1rem;
+}
+
+.gene-results {
+  margin-top: 2.5rem;
+}
+
+.gene-results__card {
+  padding: 0;
+  overflow: hidden;
+}
+
+.gene-results__table {
+  width: 100%;
+  border-collapse: collapse;
   color: var(--text);
-  font-size: 0.9rem;
 }
 
-.admin-nav a.active {
-  background: rgba(34, 211, 238, 0.25);
+.gene-results__table thead th {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.gene-results__table tbody td {
+  padding: 1.1rem 1.25rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+  vertical-align: top;
+}
+
+.gene-results__table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.gene-results__fraction {
+  display: block;
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--text);
+}
+
+.gene-results__percentage {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.gene-results__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.gene-results__placeholder {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.gene-results__morph {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.gene-results__empty {
+  padding: 2.5rem;
+  text-align: center;
+}
+
+.gene-results__empty h3 {
+  margin: 0 0 0.5rem;
+  color: var(--text);
+}
+
+.gene-results__empty p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.gene-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  border-radius: 999px;
+  padding: 0.3rem 0.65rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.gene-pill--visual {
+  background: rgba(250, 204, 21, 0.22);
+  color: #facc15;
+}
+
+.gene-pill--carrier {
+  background: rgba(34, 211, 238, 0.22);
   color: var(--accent);
 }
 
-@media (max-width: 768px) {
-  .navbar {
-    flex-direction: column;
-    gap: 1rem;
-  }
+.gene-pill--normal {
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--text-muted);
+}
 
-  .hero {
-    padding: 2rem;
-  }
+.plan-parents {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
 
-  .table {
-    display: block;
-    overflow-x: auto;
+.plan-parents li {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 1rem;
+  padding: 0.75rem 1rem;
+  background: rgba(15, 23, 42, 0.7);
+}
+
+.plan-parent__title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+@media (min-width: 1024px) {
+  .gene-selector__parents {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }

--- a/public/index.php
+++ b/public/index.php
@@ -28,7 +28,9 @@ switch ($route) {
         $settings = get_all_settings($pdo);
         $animals = get_showcased_animals($pdo);
         $listings = get_public_listings($pdo);
-        view('home', compact('settings', 'animals', 'listings'));
+        $latestNews = get_latest_published_news($pdo, 3);
+        $careHighlights = array_slice(get_published_care_articles($pdo), 0, 3);
+        view('home', compact('settings', 'animals', 'listings', 'latestNews', 'careHighlights'));
         break;
 
     case 'animals':
@@ -42,6 +44,13 @@ switch ($route) {
         $settings = get_all_settings($pdo);
         $animals = get_user_animals($pdo, current_user()['id']);
         view('animals/my_animals', compact('settings', 'animals'));
+        break;
+
+    case 'breeding':
+        require_login();
+        $settings = get_all_settings($pdo);
+        $breedingPlans = get_breeding_plans($pdo);
+        view('breeding/index', compact('settings', 'breedingPlans'));
         break;
 
     case 'adoption':
@@ -63,12 +72,99 @@ switch ($route) {
                 flash('success', 'Anfrage wurde gesendet.');
                 redirect('adoption');
             } else {
-                flash('error', 'Bitte alle Felder ausfüllen.');
+                flash('error', 'Bitte füllen Sie alle Pflichtfelder aus und ergänzen Sie eine aussagekräftige Nachricht.');
             }
         }
         $flashSuccess = flash('success');
         $flashError = flash('error');
         view('adoption/index', compact('settings', 'listings', 'flashSuccess', 'flashError'));
+        break;
+
+    case 'page':
+        $slug = $_GET['slug'] ?? '';
+        $page = $slug ? get_page_by_slug($pdo, $slug) : null;
+        if (!$page || (!$page['is_published'] && (!current_user() || !is_authorized('can_manage_settings')))) {
+            http_response_code(404);
+            view('errors/404', ['settings' => get_all_settings($pdo)]);
+            break;
+        }
+        $settings = get_all_settings($pdo);
+        view('pages/show', [
+            'settings' => $settings,
+            'page' => $page,
+            'activePageSlug' => $page['slug'],
+        ]);
+        break;
+
+    case 'news':
+        $settings = get_all_settings($pdo);
+        $slug = $_GET['slug'] ?? null;
+        if ($slug) {
+            $post = get_news_by_slug($pdo, $slug);
+            if (!$post || (!$post['is_published'] && (!current_user() || !is_authorized('can_manage_settings')))) {
+                http_response_code(404);
+                view('errors/404', ['settings' => $settings]);
+                break;
+            }
+            view('news/show', [
+                'settings' => $settings,
+                'post' => $post,
+            ]);
+        } else {
+            $newsPosts = get_published_news($pdo);
+            view('news/index', compact('settings', 'newsPosts'));
+        }
+        break;
+
+    case 'care-guide':
+        $settings = get_all_settings($pdo);
+        $careArticles = get_published_care_articles($pdo);
+        view('care/index', compact('settings', 'careArticles'));
+        break;
+
+    case 'care-article':
+        $slug = $_GET['slug'] ?? '';
+        $article = $slug ? get_care_article_by_slug($pdo, $slug) : null;
+        if (!$article || (!$article['is_published'] && (!current_user() || !is_authorized('can_manage_settings')))) {
+            http_response_code(404);
+            view('errors/404', ['settings' => get_all_settings($pdo)]);
+            break;
+        }
+        $settings = get_all_settings($pdo);
+        view('care/show', [
+            'settings' => $settings,
+            'article' => $article,
+            'activeCareSlug' => $article['slug'],
+        ]);
+        break;
+
+    case 'genetics':
+        $settings = get_all_settings($pdo);
+        $speciesList = get_genetic_species($pdo);
+        $selectedSlug = $_POST['species_slug'] ?? $_GET['species'] ?? ($speciesList[0]['slug'] ?? null);
+        $selectedSpecies = $selectedSlug ? get_genetic_species_by_slug($pdo, $selectedSlug) : null;
+        if (!$selectedSpecies && !empty($speciesList)) {
+            $selectedSpecies = get_genetic_species_by_id($pdo, (int)$speciesList[0]['id']);
+            $selectedSlug = $speciesList[0]['slug'];
+        }
+        $genes = $selectedSpecies ? get_genetic_genes($pdo, (int)$selectedSpecies['id']) : [];
+        $parentSelections = [
+            'parent1' => $_POST['parent1'] ?? [],
+            'parent2' => $_POST['parent2'] ?? [],
+        ];
+        $results = null;
+        if ($_SERVER['REQUEST_METHOD'] === 'POST' && $selectedSpecies && !empty($genes)) {
+            $results = calculate_genetic_outcomes($genes, $parentSelections['parent1'], $parentSelections['parent2']);
+        }
+        view('genetics/index', [
+            'settings' => $settings,
+            'speciesList' => $speciesList,
+            'selectedSpecies' => $selectedSpecies,
+            'selectedSpeciesSlug' => $selectedSlug,
+            'genes' => $genes,
+            'parentSelections' => $parentSelections,
+            'results' => $results,
+        ]);
         break;
 
     case 'admin/dashboard':
@@ -77,7 +173,13 @@ switch ($route) {
         $animals = get_animals($pdo);
         $listings = get_listings($pdo);
         $inquiries = get_inquiries($pdo);
-        view('admin/dashboard', compact('settings', 'animals', 'listings', 'inquiries'));
+        $pages = get_pages($pdo);
+        $newsPosts = get_news($pdo);
+        $breedingPlans = get_breeding_plans($pdo);
+        $careArticles = get_care_articles($pdo);
+        $geneticSpecies = get_genetic_species($pdo);
+        $geneticGenes = get_all_genetic_genes($pdo);
+        view('admin/dashboard', compact('settings', 'animals', 'listings', 'inquiries', 'pages', 'newsPosts', 'breedingPlans', 'careArticles', 'geneticSpecies', 'geneticGenes'));
         break;
 
     case 'admin/settings':
@@ -103,30 +205,132 @@ switch ($route) {
         view('admin/settings', compact('settings', 'flashSuccess'));
         break;
 
+    case 'admin/pages':
+        require_login();
+        if (!is_authorized('can_manage_settings')) {
+            flash('error', 'Keine Berechtigung.');
+            redirect('admin/dashboard');
+        }
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $data = [
+                'title' => trim($_POST['title'] ?? ''),
+                'slug' => trim($_POST['slug'] ?? ''),
+                'content' => $_POST['content'] ?? '',
+                'is_published' => isset($_POST['is_published']),
+                'show_in_menu' => isset($_POST['show_in_menu']),
+                'parent_id' => $_POST['parent_id'] ?? null,
+            ];
+            if ($data['title'] && $data['content']) {
+                if (!empty($_POST['id'])) {
+                    update_page($pdo, (int)$_POST['id'], $data);
+                    flash('success', 'Seite aktualisiert.');
+                } else {
+                    create_page($pdo, $data);
+                    flash('success', 'Neue Seite angelegt.');
+                }
+                redirect('admin/pages');
+            } else {
+                flash('error', 'Bitte geben Sie Titel und Inhalt ein, um die Seite zu speichern.');
+            }
+        }
+        if (isset($_GET['delete'])) {
+            delete_page($pdo, (int)$_GET['delete']);
+            flash('success', 'Seite gelöscht.');
+            redirect('admin/pages');
+        }
+        $settings = get_all_settings($pdo);
+        $pages = get_pages($pdo);
+        $editPage = null;
+        if (isset($_GET['edit'])) {
+            $editPage = get_page($pdo, (int)$_GET['edit']);
+        }
+        $flashSuccess = flash('success');
+        $flashError = flash('error');
+        view('admin/pages', compact('settings', 'pages', 'editPage', 'flashSuccess', 'flashError'));
+        break;
+
+    case 'admin/news':
+        require_login();
+        if (!is_authorized('can_manage_settings')) {
+            flash('error', 'Keine Berechtigung.');
+            redirect('admin/dashboard');
+        }
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $data = [
+                'title' => trim($_POST['title'] ?? ''),
+                'slug' => trim($_POST['slug'] ?? ''),
+                'excerpt' => $_POST['excerpt'] ?? null,
+                'content' => $_POST['content'] ?? '',
+                'is_published' => isset($_POST['is_published']),
+                'published_at' => trim($_POST['published_at'] ?? ''),
+            ];
+            if ($data['title'] && $data['content']) {
+                if (!empty($_POST['id'])) {
+                    update_news($pdo, (int)$_POST['id'], $data);
+                    flash('success', 'Neuigkeit aktualisiert.');
+                } else {
+                    create_news($pdo, $data);
+                    flash('success', 'Neuigkeit veröffentlicht.');
+                }
+                redirect('admin/news');
+            } else {
+                flash('error', 'Bitte tragen Sie einen Titel und den vollständigen Textbeitrag ein.');
+            }
+        }
+        if (isset($_GET['delete'])) {
+            delete_news($pdo, (int)$_GET['delete']);
+            flash('success', 'Neuigkeit gelöscht.');
+            redirect('admin/news');
+        }
+        $settings = get_all_settings($pdo);
+        $newsPosts = get_news($pdo);
+        $editPost = null;
+        if (isset($_GET['edit'])) {
+            $editPost = get_news_post($pdo, (int)$_GET['edit']);
+        }
+        $flashSuccess = flash('success');
+        $flashError = flash('error');
+        view('admin/news', compact('settings', 'newsPosts', 'editPost', 'flashSuccess', 'flashError'));
+        break;
+
     case 'admin/animals':
         require_login();
         if (!is_authorized('can_manage_animals')) {
             flash('error', 'Keine Berechtigung.');
             redirect('admin/dashboard');
         }
+        $prefillAnimal = null;
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $data = $_POST;
+            $data['name'] = trim($data['name'] ?? '');
+            $data['species'] = trim($data['species'] ?? '');
+            $data['age'] = trim($data['age'] ?? '');
+            $data['origin'] = trim($data['origin'] ?? '');
+            $data['special_notes'] = $data['special_notes'] ?? null;
+            $data['description'] = $data['description'] ?? null;
+            $data['genetics'] = $data['genetics'] ?? null;
             $data['is_private'] = isset($_POST['is_private']);
             $data['is_showcased'] = isset($_POST['is_showcased']);
-            if (!empty($_FILES['image']['name'])) {
-                $upload = handle_upload($_FILES['image']);
-                if ($upload) {
-                    $data['image_path'] = $upload;
-                }
-            }
-            if (!empty($data['id'])) {
-                update_animal($pdo, (int)$data['id'], $data);
-                flash('success', 'Tier aktualisiert.');
+            $data['is_piebald'] = isset($_POST['is_piebald']);
+            if ($data['name'] === '' || $data['species'] === '') {
+                flash('error', 'Bitte geben Sie sowohl einen Tiernamen als auch die Artbezeichnung an.');
+                $prefillAnimal = $data;
             } else {
-                create_animal($pdo, $data);
-                flash('success', 'Tier angelegt.');
+                if (!empty($_FILES['image']['name'])) {
+                    $upload = handle_upload($_FILES['image']);
+                    if ($upload) {
+                        $data['image_path'] = $upload;
+                    }
+                }
+                if (!empty($data['id'])) {
+                    update_animal($pdo, (int)$data['id'], $data);
+                    flash('success', 'Tier aktualisiert.');
+                } else {
+                    create_animal($pdo, $data);
+                    flash('success', 'Tier angelegt.');
+                }
+                redirect('admin/animals');
             }
-            redirect('admin/animals');
         }
         if (isset($_GET['delete'])) {
             delete_animal($pdo, (int)$_GET['delete']);
@@ -136,12 +340,128 @@ switch ($route) {
         $animals = get_animals($pdo);
         $users = get_users($pdo);
         $settings = get_all_settings($pdo);
-        $editAnimal = null;
-        if (isset($_GET['edit'])) {
+        $editAnimal = $prefillAnimal;
+        if (!$editAnimal && isset($_GET['edit'])) {
             $editAnimal = get_animal($pdo, (int)$_GET['edit']);
         }
         $flashSuccess = flash('success');
-        view('admin/animals', compact('animals', 'users', 'editAnimal', 'flashSuccess', 'settings'));
+        $flashError = flash('error');
+        view('admin/animals', compact('animals', 'users', 'editAnimal', 'flashSuccess', 'flashError', 'settings'));
+        break;
+
+    case 'admin/breeding':
+        require_login();
+        if (!is_authorized('can_manage_animals')) {
+            flash('error', 'Keine Berechtigung.');
+            redirect('admin/dashboard');
+        }
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $formType = $_POST['form'] ?? 'plan';
+            if ($formType === 'parent') {
+                $planId = (int)($_POST['plan_id'] ?? 0);
+                if ($planId) {
+                    $parentType = $_POST['parent_type'] ?? 'animal';
+                    $data = [
+                        'plan_id' => $planId,
+                        'parent_type' => $parentType === 'virtual' ? 'virtual' : 'animal',
+                        'animal_id' => $_POST['animal_id'] ?? null,
+                        'name' => trim($_POST['name'] ?? ''),
+                        'sex' => trim($_POST['sex'] ?? ''),
+                        'species' => trim($_POST['species'] ?? ''),
+                        'genetics' => trim($_POST['genetics'] ?? ''),
+                        'notes' => $_POST['notes'] ?? null,
+                    ];
+                    if ($data['parent_type'] === 'animal' && empty($data['animal_id'])) {
+                        flash('error', 'Bitte wählen Sie ein Tier aus dem Bestand oder aktivieren Sie die Option für ein virtuelles Tier.');
+                    } else {
+                        if ($data['parent_type'] === 'virtual' && !$data['name']) {
+                            $data['name'] = 'Virtueller Elternteil';
+                        }
+                        add_breeding_parent($pdo, $data);
+                        flash('success', 'Elternteil hinzugefügt.');
+                    }
+                }
+                redirect('admin/breeding', ['edit_plan' => $planId]);
+            } elseif ($formType === 'pair') {
+                $planId = (int)($_POST['pair_plan_id'] ?? 0);
+                if ($planId) {
+                    $parents = [];
+                    $labels = ['parent_a' => 'erstes Elternteil', 'parent_b' => 'zweites Elternteil'];
+                    foreach ($labels as $prefix => $label) {
+                        $type = $_POST[$prefix . '_type'] ?? 'animal';
+                        $entry = [
+                            'plan_id' => $planId,
+                            'parent_type' => $type === 'virtual' ? 'virtual' : 'animal',
+                            'animal_id' => $_POST[$prefix . '_animal_id'] ?? null,
+                            'name' => trim($_POST[$prefix . '_name'] ?? ''),
+                            'sex' => trim($_POST[$prefix . '_sex'] ?? ''),
+                            'species' => trim($_POST[$prefix . '_species'] ?? ''),
+                            'genetics' => trim($_POST[$prefix . '_genetics'] ?? ''),
+                            'notes' => $_POST[$prefix . '_notes'] ?? null,
+                        ];
+                        if ($entry['parent_type'] === 'animal') {
+                            if (empty($entry['animal_id'])) {
+                                flash('error', "Bitte wählen Sie für das {$label} ein Tier aus dem Bestand aus oder wechseln Sie zur virtuellen Eingabe.");
+                                redirect('admin/breeding', ['edit_plan' => $planId]);
+                            }
+                        } else {
+                            if ($entry['name'] === '') {
+                                $entry['name'] = 'Virtuelles Elternteil';
+                            }
+                        }
+                        $parents[] = $entry;
+                    }
+                    foreach ($parents as $entry) {
+                        add_breeding_parent($pdo, $entry);
+                    }
+                    flash('success', 'Verpaarung gespeichert.');
+                } else {
+                    flash('error', 'Bitte wählen Sie einen Zuchtplan aus.');
+                }
+                redirect('admin/breeding', ['edit_plan' => $planId]);
+            } else {
+                $data = [
+                    'title' => trim($_POST['title'] ?? ''),
+                    'season' => trim($_POST['season'] ?? ''),
+                    'notes' => $_POST['notes'] ?? null,
+                    'expected_genetics' => $_POST['expected_genetics'] ?? null,
+                    'incubation_notes' => $_POST['incubation_notes'] ?? null,
+                ];
+                if ($data['title']) {
+                    if (!empty($_POST['id'])) {
+                        update_breeding_plan($pdo, (int)$_POST['id'], $data);
+                        flash('success', 'Zuchtplan aktualisiert.');
+                        redirect('admin/breeding', ['edit_plan' => (int)$_POST['id']]);
+                    } else {
+                        $planId = create_breeding_plan($pdo, $data);
+                        flash('success', 'Zuchtplan erstellt.');
+                        redirect('admin/breeding', ['edit_plan' => $planId]);
+                    }
+                } else {
+                    flash('error', 'Bitte vergeben Sie einen aussagekräftigen Titel für den Zuchtplan.');
+                }
+            }
+        }
+        if (isset($_GET['delete_plan'])) {
+            delete_breeding_plan($pdo, (int)$_GET['delete_plan']);
+            flash('success', 'Zuchtplan gelöscht.');
+            redirect('admin/breeding');
+        }
+        if (isset($_GET['delete_parent'])) {
+            delete_breeding_parent($pdo, (int)$_GET['delete_parent']);
+            flash('success', 'Elternteil entfernt.');
+            redirect('admin/breeding', ['edit_plan' => (int)($_GET['plan'] ?? 0)]);
+        }
+        $settings = get_all_settings($pdo);
+        $animals = get_animals($pdo);
+        $breedingPlans = get_breeding_plans($pdo);
+        $editPlan = null;
+        if (isset($_GET['edit_plan'])) {
+            $editPlan = get_breeding_plan($pdo, (int)$_GET['edit_plan']);
+        }
+        $flashSuccess = flash('success');
+        $flashError = flash('error');
+        view('admin/breeding', compact('settings', 'animals', 'breedingPlans', 'editPlan', 'flashSuccess', 'flashError'));
         break;
 
     case 'admin/adoption':
@@ -181,6 +501,184 @@ switch ($route) {
         }
         $flashSuccess = flash('success');
         view('admin/adoption', compact('listings', 'animals', 'editListing', 'flashSuccess', 'settings'));
+        break;
+
+    case 'admin/care':
+        require_login();
+        if (!is_authorized('can_manage_settings')) {
+            flash('error', 'Keine Berechtigung.');
+            redirect('admin/dashboard');
+        }
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $data = [
+                'title' => trim($_POST['title'] ?? ''),
+                'slug' => trim($_POST['slug'] ?? ''),
+                'summary' => $_POST['summary'] ?? null,
+                'content' => $_POST['content'] ?? '',
+                'is_published' => isset($_POST['is_published']),
+            ];
+            if ($data['title'] && $data['content']) {
+                if (!empty($_POST['id'])) {
+                    update_care_article($pdo, (int)$_POST['id'], $data);
+                    flash('success', 'Artikel aktualisiert.');
+                } else {
+                    create_care_article($pdo, $data);
+                    flash('success', 'Artikel erstellt.');
+                }
+                redirect('admin/care');
+            } else {
+                flash('error', 'Bitte formulieren Sie einen Titel und den vollständigen Artikelinhalt.');
+            }
+        }
+        if (isset($_GET['delete'])) {
+            delete_care_article($pdo, (int)$_GET['delete']);
+            flash('success', 'Artikel gelöscht.');
+            redirect('admin/care');
+        }
+        $settings = get_all_settings($pdo);
+        $careArticles = get_care_articles($pdo);
+        $editArticle = null;
+        if (isset($_GET['edit'])) {
+            $editArticle = get_care_article($pdo, (int)$_GET['edit']);
+        }
+        $flashSuccess = flash('success');
+        $flashError = flash('error');
+        view('admin/care', compact('settings', 'careArticles', 'editArticle', 'flashSuccess', 'flashError'));
+        break;
+
+    case 'admin/genetics':
+        require_login();
+        if (!is_authorized('can_manage_settings')) {
+            flash('error', 'Keine Berechtigung.');
+            redirect('admin/dashboard');
+        }
+
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $formType = $_POST['form_type'] ?? '';
+            if ($formType === 'species') {
+                $data = [
+                    'name' => trim($_POST['name'] ?? ''),
+                    'slug' => trim($_POST['slug'] ?? ''),
+                    'scientific_name' => trim($_POST['scientific_name'] ?? ''),
+                    'description' => $_POST['description'] ?? '',
+                ];
+                if ($data['name'] === '') {
+                    flash('error', 'Bitte benennen Sie die Art, bevor Sie speichern.');
+                } else {
+                    try {
+                        if (!empty($_POST['id'])) {
+                            update_genetic_species($pdo, (int)$_POST['id'], $data);
+                            $species = get_genetic_species_by_id($pdo, (int)$_POST['id']);
+                            flash('success', 'Art aktualisiert.');
+                        } else {
+                            $newId = create_genetic_species($pdo, $data);
+                            $species = get_genetic_species_by_id($pdo, $newId);
+                            flash('success', 'Art angelegt.');
+                        }
+                        $slug = $species['slug'] ?? null;
+                        redirect('admin/genetics', $slug ? ['species' => $slug] : []);
+                    } catch (Throwable $e) {
+                        flash('error', 'Art konnte nicht gespeichert werden.');
+                    }
+                }
+            } elseif ($formType === 'gene') {
+                $speciesId = (int)($_POST['species_id'] ?? 0);
+                $data = [
+                    'species_id' => $speciesId,
+                    'name' => trim($_POST['name'] ?? ''),
+                    'slug' => trim($_POST['slug'] ?? ''),
+                    'shorthand' => trim($_POST['shorthand'] ?? ''),
+                    'inheritance_mode' => $_POST['inheritance_mode'] ?? 'recessive',
+                    'description' => $_POST['description'] ?? '',
+                    'normal_label' => $_POST['normal_label'] ?? '',
+                    'heterozygous_label' => $_POST['heterozygous_label'] ?? '',
+                    'homozygous_label' => $_POST['homozygous_label'] ?? '',
+                    'display_order' => (int)($_POST['display_order'] ?? 0),
+                ];
+                if ($data['name'] === '' || $speciesId <= 0) {
+                    flash('error', 'Bitte wählen Sie eine Art aus und vergeben Sie einen Namen für das Gen.');
+                } else {
+                    try {
+                        if (!empty($_POST['id'])) {
+                            update_genetic_gene($pdo, (int)$_POST['id'], $data);
+                            flash('success', 'Gen aktualisiert.');
+                            $gene = get_genetic_gene($pdo, (int)$_POST['id']);
+                        } else {
+                            $newId = create_genetic_gene($pdo, $data);
+                            flash('success', 'Gen angelegt.');
+                            $gene = get_genetic_gene($pdo, $newId);
+                        }
+                        $species = $gene ? get_genetic_species_by_id($pdo, (int)$gene['species_id']) : null;
+                        $slug = $species['slug'] ?? null;
+                        redirect('admin/genetics', $slug ? ['species' => $slug] : []);
+                    } catch (Throwable $e) {
+                        flash('error', 'Gen konnte nicht gespeichert werden.');
+                    }
+                }
+            }
+        }
+
+        if (isset($_GET['delete_species'])) {
+            $species = get_genetic_species_by_id($pdo, (int)$_GET['delete_species']);
+            if ($species) {
+                delete_genetic_species($pdo, (int)$species['id']);
+                flash('success', 'Art entfernt.');
+            }
+            redirect('admin/genetics');
+        }
+
+        if (isset($_GET['delete_gene'])) {
+            $gene = get_genetic_gene($pdo, (int)$_GET['delete_gene']);
+            if ($gene) {
+                delete_genetic_gene($pdo, (int)$gene['id']);
+                $species = get_genetic_species_by_id($pdo, (int)$gene['species_id']);
+                flash('success', 'Gen entfernt.');
+                $slug = $species['slug'] ?? null;
+                redirect('admin/genetics', $slug ? ['species' => $slug] : []);
+            }
+            redirect('admin/genetics');
+        }
+
+        $settings = get_all_settings($pdo);
+        $speciesList = get_genetic_species($pdo);
+        $selectedSlug = $_GET['species'] ?? $_POST['species_slug'] ?? ($speciesList[0]['slug'] ?? null);
+        $selectedSpecies = $selectedSlug ? get_genetic_species_by_slug($pdo, $selectedSlug) : null;
+        if (!$selectedSpecies && !empty($speciesList)) {
+            $selectedSpecies = get_genetic_species_by_id($pdo, (int)$speciesList[0]['id']);
+            $selectedSlug = $speciesList[0]['slug'];
+        }
+        $editSpecies = null;
+        if (isset($_GET['edit_species'])) {
+            $editSpecies = get_genetic_species_by_id($pdo, (int)$_GET['edit_species']);
+            if ($editSpecies) {
+                $selectedSpecies = $editSpecies;
+                $selectedSlug = $editSpecies['slug'];
+            }
+        }
+        $genes = $selectedSpecies ? get_genetic_genes($pdo, (int)$selectedSpecies['id']) : [];
+        $editGene = null;
+        if (isset($_GET['edit_gene'])) {
+            $editGene = get_genetic_gene($pdo, (int)$_GET['edit_gene']);
+            if ($editGene && (!$selectedSpecies || (int)$selectedSpecies['id'] !== (int)$editGene['species_id'])) {
+                $selectedSpecies = get_genetic_species_by_id($pdo, (int)$editGene['species_id']);
+                $selectedSlug = $selectedSpecies['slug'] ?? $selectedSlug;
+                $genes = $selectedSpecies ? get_genetic_genes($pdo, (int)$selectedSpecies['id']) : [];
+            }
+        }
+
+        $flashSuccess = flash('success');
+        $flashError = flash('error');
+        view('admin/genetics', [
+            'settings' => $settings,
+            'speciesList' => $speciesList,
+            'selectedSpecies' => $selectedSpecies,
+            'selectedSpeciesSlug' => $selectedSlug,
+            'genes' => $genes,
+            'editSpecies' => $editSpecies,
+            'editGene' => $editGene,
+            'flashSuccess' => $flashSuccess,
+            'flashError' => $flashError,
+        ]);
         break;
 
     case 'admin/inquiries':

--- a/public/index.php
+++ b/public/index.php
@@ -27,16 +27,71 @@ switch ($route) {
     case 'home':
         $settings = get_all_settings($pdo);
         $animals = get_showcased_animals($pdo);
-        $listings = get_public_listings($pdo);
+        $listingsPreview = array_slice(get_public_listings($pdo), 0, 4);
         $latestNews = get_latest_published_news($pdo, 3);
         $careHighlights = array_slice(get_published_care_articles($pdo), 0, 3);
-        view('home', compact('settings', 'animals', 'listings', 'latestNews', 'careHighlights'));
+        $featureGeneticsTeaser = filter_var(getenv('FEATURE_GENETICS_TEASER') ?? '1', FILTER_VALIDATE_BOOLEAN);
+        $pageMeta = [
+            'title' => 'Startseite',
+            'description' => trim(strip_tags($settings['hero_intro'] ?? $settings['site_tagline'] ?? '')),
+            'breadcrumbs' => build_breadcrumbs([
+                ['name' => 'Start', 'url' => canonical_url('/')],
+            ]),
+            'og_image' => $settings['hero_image'] ?? ORG_LOGO_URL,
+            'schema' => [
+                [
+                    '@context' => 'https://schema.org',
+                    '@type' => 'WebPage',
+                    'name' => SITE_NAME . ' – Startseite',
+                    'url' => canonical_url('/'),
+                    'inLanguage' => PRIMARY_LANGUAGE,
+                    'about' => PRIMARY_TOPIC,
+                    'description' => trim(strip_tags($settings['hero_intro'] ?? $settings['site_tagline'] ?? '')),
+                ],
+            ],
+        ];
+        view('home', [
+            'settings' => $settings,
+            'animals' => $animals,
+            'listings' => $listingsPreview,
+            'latestNews' => $latestNews,
+            'careHighlights' => $careHighlights,
+            'featureGeneticsTeaser' => $featureGeneticsTeaser,
+            'pageMeta' => $pageMeta,
+        ]);
         break;
+
+    case 'healthz':
+        header('Content-Type: application/json');
+        echo json_encode([
+            'status' => 'ok',
+            'time' => date(DATE_ATOM),
+            'db' => $pdo ? 'connected' : 'unavailable',
+        ], JSON_UNESCAPED_SLASHES);
+        exit;
 
     case 'animals':
         $settings = get_all_settings($pdo);
         $animals = get_public_animals($pdo);
-        view('animals/index', compact('settings', 'animals'));
+        $pageMeta = [
+            'title' => 'Tierübersicht',
+            'description' => 'Überblick über verfügbare und vergangene Tiere inkl. Morphs und Besonderheiten.',
+            'breadcrumbs' => build_breadcrumbs([
+                ['name' => 'Start', 'url' => canonical_url('/')],
+                ['name' => 'Tierübersicht'],
+            ]),
+            'schema' => [
+                [
+                    '@context' => 'https://schema.org',
+                    '@type' => 'CollectionPage',
+                    'name' => 'Tierübersicht',
+                    'inLanguage' => PRIMARY_LANGUAGE,
+                    'url' => canonical_url('/index.php?route=animals'),
+                    'about' => PRIMARY_TOPIC,
+                ],
+            ],
+        ];
+        view('animals/index', compact('settings', 'animals', 'pageMeta'));
         break;
 
     case 'my-animals':
@@ -77,7 +132,59 @@ switch ($route) {
         }
         $flashSuccess = flash('success');
         $flashError = flash('error');
-        view('adoption/index', compact('settings', 'listings', 'flashSuccess', 'flashError'));
+        $productSchemas = array_map(static function ($listing) {
+            $priceRaw = $listing['price'] ?? '';
+            $priceNumeric = null;
+            if ($priceRaw !== null && $priceRaw !== '') {
+                $normalized = preg_replace('/[^0-9,\.]/', '', (string)$priceRaw);
+                if ($normalized !== '') {
+                    $priceNumeric = number_format((float)str_replace(',', '.', $normalized), 2, '.', '');
+                }
+            }
+
+            $imagePath = !empty($listing['image_path']) ? absolute_url($listing['image_path']) : ORG_LOGO_URL;
+            $nameParts = array_filter([
+                $listing['species'] ?? null,
+                $listing['title'] ?? null,
+            ]);
+            return [
+                '@context' => 'https://schema.org',
+                '@type' => 'Product',
+                'name' => implode(' – ', $nameParts),
+                'description' => trim(strip_tags($listing['description'] ?? '')),
+                'image' => [$imagePath],
+                'category' => 'Pets',
+                'brand' => ORG_NAME,
+                'offers' => [
+                    '@type' => 'Offer',
+                    'price' => $priceNumeric ?? '0.00',
+                    'priceCurrency' => 'EUR',
+                    'availability' => ($listing['status'] ?? '') === 'available' ? 'https://schema.org/InStock' : 'https://schema.org/OutOfStock',
+                    'url' => canonical_url('/index.php?route=adoption#listing-' . $listing['id']),
+                ],
+            ];
+        }, $listings);
+        $ogImage = !empty($productSchemas) ? ($productSchemas[0]['image'][0] ?? ORG_LOGO_URL) : ($settings['hero_image'] ?? ORG_LOGO_URL);
+        $pageMeta = [
+            'title' => 'Tierabgabe & Vermittlung',
+            'description' => trim(strip_tags($settings['adoption_intro'] ?? '')) ?: 'Transparente Abgabebedingungen und verfügbare Tiere inklusive Gesundheitsstatus.',
+            'breadcrumbs' => build_breadcrumbs([
+                ['name' => 'Start', 'url' => canonical_url('/')],
+                ['name' => 'Tierabgabe'],
+            ]),
+            'og_image' => $ogImage,
+            'schema' => array_merge([
+                [
+                    '@context' => 'https://schema.org',
+                    '@type' => 'CollectionPage',
+                    'name' => 'Tiervermittlung',
+                    'url' => canonical_url('/index.php?route=adoption'),
+                    'inLanguage' => PRIMARY_LANGUAGE,
+                    'description' => trim(strip_tags($settings['adoption_intro'] ?? '')),
+                ],
+            ], $productSchemas),
+        ];
+        view('adoption/index', compact('settings', 'listings', 'flashSuccess', 'flashError', 'pageMeta'));
         break;
 
     case 'page':
@@ -89,10 +196,30 @@ switch ($route) {
             break;
         }
         $settings = get_all_settings($pdo);
+        $summary = trim($page['summary'] ?? mb_substr(strip_tags($page['content'] ?? ''), 0, 160));
+        $pageMeta = [
+            'title' => $page['title'],
+            'description' => $summary,
+            'breadcrumbs' => build_breadcrumbs([
+                ['name' => 'Start', 'url' => canonical_url('/')],
+                ['name' => $page['title']],
+            ]),
+            'schema' => [
+                [
+                    '@context' => 'https://schema.org',
+                    '@type' => 'WebPage',
+                    'name' => $page['title'],
+                    'url' => canonical_url('/index.php?route=page&slug=' . urlencode($page['slug'])),
+                    'description' => $summary,
+                    'inLanguage' => PRIMARY_LANGUAGE,
+                ],
+            ],
+        ];
         view('pages/show', [
             'settings' => $settings,
             'page' => $page,
             'activePageSlug' => $page['slug'],
+            'pageMeta' => $pageMeta,
         ]);
         break;
 
@@ -106,20 +233,89 @@ switch ($route) {
                 view('errors/404', ['settings' => $settings]);
                 break;
             }
+            $summary = trim($post['excerpt'] ?? mb_substr(strip_tags($post['content'] ?? ''), 0, 160));
+            $pageMeta = [
+                'title' => $post['title'],
+                'description' => $summary,
+                'breadcrumbs' => build_breadcrumbs([
+                    ['name' => 'Start', 'url' => canonical_url('/')],
+                    ['name' => 'Neuigkeiten', 'url' => canonical_url('/index.php?route=news')],
+                    ['name' => $post['title']],
+                ]),
+                'type' => 'article',
+                'og_type' => 'article',
+                'schema' => [
+                    [
+                        '@context' => 'https://schema.org',
+                        '@type' => 'Article',
+                        'headline' => $post['title'],
+                        'inLanguage' => PRIMARY_LANGUAGE,
+                        'author' => ['@type' => 'Organization', 'name' => ORG_NAME],
+                        'datePublished' => $post['published_at'] ?: $post['created_at'],
+                        'dateModified' => $post['updated_at'] ?? $post['published_at'] ?? $post['created_at'],
+                        'image' => [ORG_LOGO_URL],
+                        'mainEntityOfPage' => canonical_url('/index.php?route=news&slug=' . urlencode($post['slug'])),
+                        'description' => $summary,
+                    ],
+                ],
+            ];
             view('news/show', [
                 'settings' => $settings,
                 'post' => $post,
+                'pageMeta' => $pageMeta,
             ]);
         } else {
             $newsPosts = get_published_news($pdo);
-            view('news/index', compact('settings', 'newsPosts'));
+            $pageMeta = [
+                'title' => 'Neuigkeiten',
+                'description' => 'Aktuelle Meldungen, Pflege-Updates und Veranstaltungshinweise rund um unsere Bartagamen.',
+                'breadcrumbs' => build_breadcrumbs([
+                    ['name' => 'Start', 'url' => canonical_url('/')],
+                    ['name' => 'Neuigkeiten'],
+                ]),
+                'schema' => [
+                    [
+                        '@context' => 'https://schema.org',
+                        '@type' => 'Blog',
+                        'name' => 'FeroxZ Neuigkeiten',
+                        'url' => canonical_url('/index.php?route=news'),
+                        'inLanguage' => PRIMARY_LANGUAGE,
+                    ],
+                ],
+            ];
+            view('news/index', compact('settings', 'newsPosts', 'pageMeta'));
         }
         break;
 
     case 'care-guide':
         $settings = get_all_settings($pdo);
         $careArticles = get_published_care_articles($pdo);
-        view('care/index', compact('settings', 'careArticles'));
+        $itemListElements = [];
+        foreach (array_values($careArticles) as $index => $article) {
+            $itemListElements[] = [
+                '@type' => 'ListItem',
+                'position' => $index + 1,
+                'name' => $article['title'],
+                'url' => canonical_url('/index.php?route=care-article&slug=' . urlencode($article['slug'])),
+            ];
+        }
+        $pageMeta = [
+            'title' => 'Pflegeleitfaden Bartagame',
+            'description' => 'Komplette Pflegeanleitungen für Bartagamen inklusive Habitat, UV, Ernährung und Gesundheit.',
+            'breadcrumbs' => build_breadcrumbs([
+                ['name' => 'Start', 'url' => canonical_url('/')],
+                ['name' => 'Pflegeleitfaden'],
+            ]),
+            'schema' => [
+                [
+                    '@context' => 'https://schema.org',
+                    '@type' => 'ItemList',
+                    'name' => 'Pflegeleitfäden Bartagame',
+                    'itemListElement' => $itemListElements,
+                ],
+            ],
+        ];
+        view('care/index', compact('settings', 'careArticles', 'pageMeta'));
         break;
 
     case 'care-article':
@@ -131,10 +327,37 @@ switch ($route) {
             break;
         }
         $settings = get_all_settings($pdo);
+        $summary = trim($article['summary'] ?? mb_substr(strip_tags($article['content'] ?? ''), 0, 160));
+        $pageMeta = [
+            'title' => $article['title'],
+            'description' => $summary,
+            'breadcrumbs' => build_breadcrumbs([
+                ['name' => 'Start', 'url' => canonical_url('/')],
+                ['name' => 'Pflegeleitfaden', 'url' => canonical_url('/index.php?route=care-guide')],
+                ['name' => $article['title']],
+            ]),
+            'type' => 'article',
+            'og_type' => 'article',
+            'schema' => [
+                [
+                    '@context' => 'https://schema.org',
+                    '@type' => 'Article',
+                    'headline' => $article['title'],
+                    'inLanguage' => PRIMARY_LANGUAGE,
+                    'author' => ['@type' => 'Organization', 'name' => ORG_NAME],
+                    'datePublished' => $article['published_at'] ?: $article['created_at'],
+                    'dateModified' => $article['updated_at'] ?? $article['published_at'] ?? $article['created_at'],
+                    'image' => [ORG_LOGO_URL],
+                    'mainEntityOfPage' => canonical_url('/index.php?route=care-article&slug=' . urlencode($article['slug'])),
+                    'description' => $summary,
+                ],
+            ],
+        ];
         view('care/show', [
             'settings' => $settings,
             'article' => $article,
             'activeCareSlug' => $article['slug'],
+            'pageMeta' => $pageMeta,
         ]);
         break;
 
@@ -156,6 +379,25 @@ switch ($route) {
         if ($_SERVER['REQUEST_METHOD'] === 'POST' && $selectedSpecies && !empty($genes)) {
             $results = calculate_genetic_outcomes($genes, $parentSelections['parent1'], $parentSelections['parent2']);
         }
+        $pageMeta = [
+            'title' => 'Genetik Rechner',
+            'description' => 'Interaktiver Rechner für Bartagamen-Genetik zur Planung verantwortungsvoller Verpaarungen.',
+            'breadcrumbs' => build_breadcrumbs([
+                ['name' => 'Start', 'url' => canonical_url('/')],
+                ['name' => 'Genetik-Rechner'],
+            ]),
+            'schema' => [
+                [
+                    '@context' => 'https://schema.org',
+                    '@type' => 'SoftwareApplication',
+                    'name' => 'FeroxZ Genetik Rechner',
+                    'applicationCategory' => 'EducationApplication',
+                    'operatingSystem' => 'Web',
+                    'url' => canonical_url('/index.php?route=genetics'),
+                    'offers' => ['@type' => 'Offer', 'price' => '0', 'priceCurrency' => 'EUR'],
+                ],
+            ],
+        ];
         view('genetics/index', [
             'settings' => $settings,
             'speciesList' => $speciesList,
@@ -164,6 +406,7 @@ switch ($route) {
             'genes' => $genes,
             'parentSelections' => $parentSelections,
             'results' => $results,
+            'pageMeta' => $pageMeta,
         ]);
         break;
 
@@ -308,6 +551,7 @@ switch ($route) {
             $data['origin'] = trim($data['origin'] ?? '');
             $data['special_notes'] = $data['special_notes'] ?? null;
             $data['description'] = $data['description'] ?? null;
+            $data['sex'] = normalize_sex($data['sex'] ?? null);
             $data['genetics'] = $data['genetics'] ?? null;
             $data['is_private'] = isset($_POST['is_private']);
             $data['is_showcased'] = isset($_POST['is_showcased']);
@@ -366,7 +610,7 @@ switch ($route) {
                         'parent_type' => $parentType === 'virtual' ? 'virtual' : 'animal',
                         'animal_id' => $_POST['animal_id'] ?? null,
                         'name' => trim($_POST['name'] ?? ''),
-                        'sex' => trim($_POST['sex'] ?? ''),
+                        'sex' => normalize_sex($_POST['sex'] ?? null),
                         'species' => trim($_POST['species'] ?? ''),
                         'genetics' => trim($_POST['genetics'] ?? ''),
                         'notes' => $_POST['notes'] ?? null,
@@ -394,7 +638,7 @@ switch ($route) {
                             'parent_type' => $type === 'virtual' ? 'virtual' : 'animal',
                             'animal_id' => $_POST[$prefix . '_animal_id'] ?? null,
                             'name' => trim($_POST[$prefix . '_name'] ?? ''),
-                            'sex' => trim($_POST[$prefix . '_sex'] ?? ''),
+                            'sex' => normalize_sex($_POST[$prefix . '_sex'] ?? null),
                             'species' => trim($_POST[$prefix . '_species'] ?? ''),
                             'genetics' => trim($_POST[$prefix . '_genetics'] ?? ''),
                             'notes' => $_POST[$prefix . '_notes'] ?? null,
@@ -472,6 +716,7 @@ switch ($route) {
         }
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $data = $_POST;
+            $data['sex'] = normalize_sex($data['sex'] ?? null);
             if (!empty($_FILES['image']['name'])) {
                 $upload = handle_upload($_FILES['image']);
                 if ($upload) {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://bartagame.eu/sitemap.xml

--- a/public/sitemap.php
+++ b/public/sitemap.php
@@ -1,0 +1,48 @@
+<?php
+require_once __DIR__ . '/../app/bootstrap.php';
+
+header('Content-Type: application/xml; charset=utf-8');
+
+$urls = [];
+$now = date('c');
+$urls[] = ['loc' => canonical_url('/'), 'lastmod' => $now, 'changefreq' => 'daily'];
+$urls[] = ['loc' => canonical_url('/index.php?route=animals'), 'changefreq' => 'weekly'];
+$urls[] = ['loc' => canonical_url('/index.php?route=adoption'), 'changefreq' => 'daily'];
+$urls[] = ['loc' => canonical_url('/index.php?route=care-guide'), 'changefreq' => 'weekly'];
+$urls[] = ['loc' => canonical_url('/index.php?route=genetics'), 'changefreq' => 'weekly'];
+$urls[] = ['loc' => canonical_url('/index.php?route=news'), 'changefreq' => 'weekly'];
+
+foreach (get_public_animals($pdo) as $animal) {
+    $urls[] = ['loc' => canonical_url('/index.php?route=animals') . '#animal-' . $animal['id'], 'changefreq' => 'monthly'];
+}
+foreach (get_public_listings($pdo) as $listing) {
+    $urls[] = ['loc' => canonical_url('/index.php?route=adoption') . '#listing-' . $listing['id'], 'changefreq' => 'daily'];
+}
+foreach (get_published_care_articles($pdo) as $article) {
+    $urls[] = ['loc' => canonical_url('/index.php?route=care-article&slug=' . urlencode($article['slug'])), 'changefreq' => 'monthly'];
+}
+foreach (get_published_news($pdo) as $post) {
+    $urls[] = ['loc' => canonical_url('/index.php?route=news&slug=' . urlencode($post['slug'])), 'changefreq' => 'weekly'];
+}
+foreach (get_navigation_pages($pdo) as $page) {
+    $urls[] = ['loc' => canonical_url('/index.php?route=page&slug=' . urlencode($page['slug'])), 'changefreq' => 'monthly'];
+    foreach ($page['children'] ?? [] as $child) {
+        $urls[] = ['loc' => canonical_url('/index.php?route=page&slug=' . urlencode($child['slug'])), 'changefreq' => 'monthly'];
+    }
+}
+
+echo '<?xml version="1.0" encoding="UTF-8"?>';
+echo '\n';
+echo '<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">';
+foreach ($urls as $entry) {
+    echo '\n  <url>';
+    echo '\n    <loc>' . htmlspecialchars($entry['loc'], ENT_XML1) . '</loc>';
+    if (!empty($entry['lastmod'])) {
+        echo '\n    <lastmod>' . htmlspecialchars($entry['lastmod'], ENT_XML1) . '</lastmod>';
+    }
+    if (!empty($entry['changefreq'])) {
+        echo '\n    <changefreq>' . htmlspecialchars($entry['changefreq'], ENT_XML1) . '</changefreq>';
+    }
+    echo '\n  </url>';
+}
+echo '\n</urlset>';

--- a/public/views/admin/adoption.php
+++ b/public/views/admin/adoption.php
@@ -1,17 +1,29 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
-<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
-<h1>Tierabgabe verwalten</h1>
+<section class="admin-shell">
+<header class="admin-page-header">
+    <div>
+        <h1 class="admin-title">Tierabgabe verwalten</h1>
+        <p class="admin-subtitle">Steuere Abgaben so, dass jede Bartagame in einen passenden Lebensraum wechselt – transparent, minimalistisch, warm.</p>
+    </div>
+    <div class="admin-meta">
+        <span class="badge">Adoptionsfluss</span>
+        <span><?= count($listings) ?> Inserate aktiv</span>
+    </div>
+</header>
 <?php include __DIR__ . '/nav.php'; ?>
+<div class="admin-section">
 <?php if ($flashSuccess): ?>
     <div class="alert alert-success" role="status" aria-live="polite"><?= htmlspecialchars($flashSuccess) ?></div>
 <?php endif; ?>
-<div class="grid" style="grid-template-columns:2fr 1fr;gap:2rem;align-items:start;">
+<div class="admin-layout">
     <div class="card">
         <h2>Inserate</h2>
-        <table class="table">
+        <div class="table-responsive">
+            <table class="table">
             <thead>
                 <tr>
                     <th>Titel</th>
+                    <th>Geschlecht</th>
                     <th>Status</th>
                     <th>Preis</th>
                     <th></th>
@@ -21,6 +33,10 @@
                 <?php foreach ($listings as $listing): ?>
                     <tr>
                         <td><?= htmlspecialchars($listing['title']) ?></td>
+                        <td>
+                            <?php $sexBadge = render_sex_badge($listing['sex'] ?? null); ?>
+                            <?= $sexBadge ?: "<span class='text-muted'>–</span>" ?>
+                        </td>
                         <td><?= htmlspecialchars($listing['status']) ?></td>
                         <td><?= htmlspecialchars($listing['price'] ?? 'n/a') ?></td>
                         <td>
@@ -30,7 +46,8 @@
                     </tr>
                 <?php endforeach; ?>
             </tbody>
-        </table>
+            </table>
+        </div>
     </div>
     <div class="card">
         <h2><?= $editListing ? 'Inserat bearbeiten' : 'Neues Inserat' ?></h2>
@@ -52,6 +69,7 @@
             <label>Art
                 <input type="text" name="species" value="<?= htmlspecialchars($editListing['species'] ?? '') ?>">
             </label>
+            <?= render_gender_field('sex', $editListing['sex'] ?? null, ['id_base' => 'listing-sex', 'required' => true]) ?>
             <label>Preis
                 <input type="text" name="price" value="<?= htmlspecialchars($editListing['price'] ?? '') ?>">
             </label>
@@ -81,6 +99,7 @@
             <button type="submit">Speichern</button>
         </form>
     </div>
+</div>
 </div>
 </section>
 <?php include __DIR__ . '/../partials/footer.php'; ?>

--- a/public/views/admin/adoption.php
+++ b/public/views/admin/adoption.php
@@ -1,8 +1,9 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
+<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
 <h1>Tierabgabe verwalten</h1>
 <?php include __DIR__ . '/nav.php'; ?>
 <?php if ($flashSuccess): ?>
-    <div class="alert alert-success"><?= htmlspecialchars($flashSuccess) ?></div>
+    <div class="alert alert-success" role="status" aria-live="polite"><?= htmlspecialchars($flashSuccess) ?></div>
 <?php endif; ?>
 <div class="grid" style="grid-template-columns:2fr 1fr;gap:2rem;align-items:start;">
     <div class="card">
@@ -51,14 +52,14 @@
             <label>Art
                 <input type="text" name="species" value="<?= htmlspecialchars($editListing['species'] ?? '') ?>">
             </label>
-            <label>Genetik
-                <textarea name="genetics"><?= htmlspecialchars($editListing['genetics'] ?? '') ?></textarea>
-            </label>
             <label>Preis
                 <input type="text" name="price" value="<?= htmlspecialchars($editListing['price'] ?? '') ?>">
             </label>
+            <label>Genetik
+                <textarea name="genetics" class="rich-text"><?= htmlspecialchars($editListing['genetics'] ?? '') ?></textarea>
+            </label>
             <label>Beschreibung
-                <textarea name="description"><?= htmlspecialchars($editListing['description'] ?? '') ?></textarea>
+                <textarea name="description" class="rich-text"><?= htmlspecialchars($editListing['description'] ?? '') ?></textarea>
             </label>
             <label>Status
                 <select name="status">
@@ -81,4 +82,5 @@
         </form>
     </div>
 </div>
+</section>
 <?php include __DIR__ . '/../partials/footer.php'; ?>

--- a/public/views/admin/animals.php
+++ b/public/views/admin/animals.php
@@ -1,22 +1,34 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
-<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
-<h1>Tiere verwalten</h1>
+<section class="admin-shell">
+<header class="admin-page-header">
+    <div>
+        <h1 class="admin-title">Tiere verwalten</h1>
+        <p class="admin-subtitle">Kuratiere den warmen Lebensraum deiner Bartagamen – vom Portfolio bis zu den feinsten Genetik-Notizen.</p>
+    </div>
+    <div class="admin-meta">
+        <span class="badge">Habitat-Übersicht</span>
+        <span><?= count($animals) ?> Tiere gelistet</span>
+    </div>
+</header>
 <?php include __DIR__ . '/nav.php'; ?>
+<div class="admin-section">
 <?php if ($flashSuccess): ?>
     <div class="alert alert-success" role="status" aria-live="polite"><?= htmlspecialchars($flashSuccess) ?></div>
 <?php endif; ?>
 <?php if (!empty($flashError)): ?>
     <div class="alert alert-error" role="alert" aria-live="assertive"><?= htmlspecialchars($flashError) ?></div>
 <?php endif; ?>
-<div class="grid" style="grid-template-columns:2fr 1fr;gap:2rem;align-items:start;">
+<div class="admin-layout">
     <div class="card">
         <h2>Bestand</h2>
-        <table class="table">
+        <div class="table-responsive">
+            <table class="table">
             <thead>
                 <tr>
                     <th>Name</th>
                     <th>Species</th>
                     <th>Eigentümer</th>
+                    <th>Geschlecht</th>
                     <th>Status</th>
                     <th></th>
                 </tr>
@@ -32,6 +44,10 @@
                         </td>
                         <td><?= htmlspecialchars($animal['species']) ?></td>
                         <td><?= htmlspecialchars($animal['owner_name'] ?? '–') ?></td>
+                        <td>
+                            <?php $sexBadge = render_sex_badge($animal['sex'] ?? null); ?>
+                            <?= $sexBadge ?: "<span class='text-muted'>–</span>" ?>
+                        </td>
                         <td>
                             <?php if ($animal['is_private']): ?>
                                 <span class="badge">Privat</span>
@@ -50,7 +66,8 @@
                     </tr>
                 <?php endforeach; ?>
             </tbody>
-        </table>
+            </table>
+        </div>
     </div>
     <div class="card">
         <h2><?= $editAnimal ? 'Tier bearbeiten' : 'Neues Tier' ?></h2>
@@ -67,6 +84,7 @@
             <label>Alter
                 <input type="text" name="age" value="<?= htmlspecialchars($editAnimal['age'] ?? '') ?>">
             </label>
+            <?= render_gender_field('sex', $editAnimal['sex'] ?? null, ['id_base' => 'animal-sex', 'required' => true]) ?>
             <label>Genetik
                 <textarea name="genetics" class="rich-text"><?= htmlspecialchars($editAnimal['genetics'] ?? '') ?></textarea>
             </label>
@@ -94,18 +112,22 @@
                     <?php endforeach; ?>
                 </select>
             </label>
-            <label style="display:flex;align-items:center;gap:0.5rem;">
-                <input type="checkbox" name="is_private" value="1" <?= !empty($editAnimal['is_private']) ? 'checked' : '' ?>> Privat
+            <label class="form-switch">
+                <input type="checkbox" name="is_private" value="1" <?= !empty($editAnimal['is_private']) ? 'checked' : '' ?>>
+                <span>Privat</span>
             </label>
-            <label style="display:flex;align-items:center;gap:0.5rem;">
-                <input type="checkbox" name="is_showcased" value="1" <?= !empty($editAnimal['is_showcased']) ? 'checked' : '' ?>> In Highlights anzeigen
+            <label class="form-switch">
+                <input type="checkbox" name="is_showcased" value="1" <?= !empty($editAnimal['is_showcased']) ? 'checked' : '' ?>>
+                <span>In Highlights anzeigen</span>
             </label>
-            <label style="display:flex;align-items:center;gap:0.5rem;">
-                <input type="checkbox" name="is_piebald" value="1" <?= !empty($editAnimal['is_piebald']) ? 'checked' : '' ?>> Als gescheckt markieren
+            <label class="form-switch">
+                <input type="checkbox" name="is_piebald" value="1" <?= !empty($editAnimal['is_piebald']) ? 'checked' : '' ?>>
+                <span>Als gescheckt markieren</span>
             </label>
             <button type="submit">Speichern</button>
         </form>
     </div>
+</div>
 </div>
 </section>
 <?php include __DIR__ . '/../partials/footer.php'; ?>

--- a/public/views/admin/animals.php
+++ b/public/views/admin/animals.php
@@ -1,8 +1,12 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
+<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
 <h1>Tiere verwalten</h1>
 <?php include __DIR__ . '/nav.php'; ?>
 <?php if ($flashSuccess): ?>
-    <div class="alert alert-success"><?= htmlspecialchars($flashSuccess) ?></div>
+    <div class="alert alert-success" role="status" aria-live="polite"><?= htmlspecialchars($flashSuccess) ?></div>
+<?php endif; ?>
+<?php if (!empty($flashError)): ?>
+    <div class="alert alert-error" role="alert" aria-live="assertive"><?= htmlspecialchars($flashError) ?></div>
 <?php endif; ?>
 <div class="grid" style="grid-template-columns:2fr 1fr;gap:2rem;align-items:start;">
     <div class="card">
@@ -20,7 +24,12 @@
             <tbody>
                 <?php foreach ($animals as $animal): ?>
                     <tr>
-                        <td><?= htmlspecialchars($animal['name']) ?></td>
+                        <td>
+                            <?= htmlspecialchars($animal['name']) ?>
+                            <?php if (!empty($animal['is_piebald'])): ?>
+                                <span class="animal-marker" title="Geschecktes Tier" aria-label="Geschecktes Tier">⬟</span>
+                            <?php endif; ?>
+                        </td>
                         <td><?= htmlspecialchars($animal['species']) ?></td>
                         <td><?= htmlspecialchars($animal['owner_name'] ?? '–') ?></td>
                         <td>
@@ -28,7 +37,10 @@
                                 <span class="badge">Privat</span>
                             <?php endif; ?>
                             <?php if ($animal['is_showcased']): ?>
-                                <span class="badge">Showcase</span>
+                                <span class="badge">Highlight</span>
+                            <?php endif; ?>
+                            <?php if (!empty($animal['is_piebald'])): ?>
+                                <span class="badge badge-pattern">Gescheckt</span>
                             <?php endif; ?>
                         </td>
                         <td>
@@ -56,16 +68,16 @@
                 <input type="text" name="age" value="<?= htmlspecialchars($editAnimal['age'] ?? '') ?>">
             </label>
             <label>Genetik
-                <textarea name="genetics"><?= htmlspecialchars($editAnimal['genetics'] ?? '') ?></textarea>
+                <textarea name="genetics" class="rich-text"><?= htmlspecialchars($editAnimal['genetics'] ?? '') ?></textarea>
             </label>
             <label>Herkunft
                 <input type="text" name="origin" value="<?= htmlspecialchars($editAnimal['origin'] ?? '') ?>">
             </label>
             <label>Besonderheiten
-                <textarea name="special_notes"><?= htmlspecialchars($editAnimal['special_notes'] ?? '') ?></textarea>
+                <textarea name="special_notes" class="rich-text"><?= htmlspecialchars($editAnimal['special_notes'] ?? '') ?></textarea>
             </label>
             <label>Beschreibung
-                <textarea name="description"><?= htmlspecialchars($editAnimal['description'] ?? '') ?></textarea>
+                <textarea name="description" class="rich-text"><?= htmlspecialchars($editAnimal['description'] ?? '') ?></textarea>
             </label>
             <label>Bild
                 <input type="file" name="image" accept="image/*">
@@ -88,8 +100,12 @@
             <label style="display:flex;align-items:center;gap:0.5rem;">
                 <input type="checkbox" name="is_showcased" value="1" <?= !empty($editAnimal['is_showcased']) ? 'checked' : '' ?>> In Highlights anzeigen
             </label>
+            <label style="display:flex;align-items:center;gap:0.5rem;">
+                <input type="checkbox" name="is_piebald" value="1" <?= !empty($editAnimal['is_piebald']) ? 'checked' : '' ?>> Als gescheckt markieren
+            </label>
             <button type="submit">Speichern</button>
         </form>
     </div>
 </div>
+</section>
 <?php include __DIR__ . '/../partials/footer.php'; ?>

--- a/public/views/admin/breeding.php
+++ b/public/views/admin/breeding.php
@@ -1,7 +1,17 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
-<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
-<h1>Zuchtplanung</h1>
+<section class="admin-shell">
+<header class="admin-page-header">
+    <div>
+        <h1 class="admin-title">Zuchtplanung</h1>
+        <p class="admin-subtitle">Gestalte kommende Generationen deiner Pogona vitticeps mit klarer, temperaturstabiler Übersicht – von Plänen bis Verpaarungen.</p>
+    </div>
+    <div class="admin-meta">
+        <span class="badge">Zuchtlinie</span>
+        <span><?= count($breedingPlans) ?> aktive Pläne</span>
+    </div>
+</header>
 <?php include __DIR__ . '/nav.php'; ?>
+<div class="admin-section">
 <?php if ($flashSuccess): ?>
     <div class="alert alert-success" role="status" aria-live="polite"><?= htmlspecialchars($flashSuccess) ?></div>
 <?php endif; ?>
@@ -20,7 +30,7 @@
         }
     }
 ?>
-<div class="grid" style="grid-template-columns:2fr 1fr;gap:2rem;align-items:start;">
+<div class="admin-layout">
     <div class="card">
         <h2>Aktive Pläne</h2>
         <?php if (empty($breedingPlans)): ?>
@@ -65,8 +75,8 @@
                                     <li>
                                         <div class="plan-parent__title">
                                             <strong><?= htmlspecialchars($parent['parent_type'] === 'virtual' ? ($parent['name'] ?: 'Virtuell') : ($parent['animal_name'] ?? $parent['name'] ?? 'Unbenannt')) ?></strong>
-                                            <?php if ($parent['sex']): ?>
-                                                <span class="badge"><?= htmlspecialchars(strtoupper($parent['sex'])) ?></span>
+                                            <?php if (!empty($parent['sex'])): ?>
+                                                <?= render_sex_badge($parent['sex']) ?>
                                             <?php endif; ?>
                                         </div>
                                         <div class="text-muted">
@@ -118,7 +128,7 @@
             <button type="submit">Zuchtplan speichern</button>
         </form>
         <?php if (!empty($breedingPlans)): ?>
-            <hr style="margin:2rem 0;opacity:0.3;">
+            <hr class="admin-divider">
             <h3>Elterntier hinzufügen</h3>
             <form method="post">
                 <input type="hidden" name="form" value="parent">
@@ -157,9 +167,7 @@
                 <label>Name (für virtuelle Eltern)
                     <input type="text" name="name" value="">
                 </label>
-                <label>Geschlecht (m/w)
-                    <input type="text" name="sex" value="">
-                </label>
+                <?= render_gender_field('sex', $_POST['sex'] ?? null, ['id_base' => 'breeding-sex']) ?>
                 <label>Art / Lokalität
                     <input type="text" name="species" value="">
                 </label>
@@ -171,7 +179,7 @@
             </label>
                 <button type="submit">Elternteil speichern</button>
             </form>
-            <hr style="margin:2rem 0;opacity:0.3;">
+            <hr class="admin-divider">
             <h3>Verpaarung anlegen</h3>
             <form method="post" data-breeding-pair-form>
                 <input type="hidden" name="form" value="pair">
@@ -216,9 +224,7 @@
                             <label>Name
                                 <input type="text" name="parent_a_name">
                             </label>
-                            <label>Geschlecht (m/w)
-                                <input type="text" name="parent_a_sex">
-                            </label>
+                            <?= render_gender_field('parent_a_sex', $_POST['parent_a_sex'] ?? null, ['id_base' => 'parent-a-sex']) ?>
                             <label>Art / Lokalität
                                 <input type="text" name="parent_a_species">
                             </label>
@@ -263,9 +269,7 @@
                             <label>Name
                                 <input type="text" name="parent_b_name">
                             </label>
-                            <label>Geschlecht (m/w)
-                                <input type="text" name="parent_b_sex">
-                            </label>
+                            <?= render_gender_field('parent_b_sex', $_POST['parent_b_sex'] ?? null, ['id_base' => 'parent-b-sex']) ?>
                             <label>Art / Lokalität
                                 <input type="text" name="parent_b_species">
                             </label>
@@ -281,6 +285,7 @@
                 <button type="submit">Verpaarung speichern</button>
             </form>
         <?php endif; ?>
+</div>
 </div>
 </div>
 <script>

--- a/public/views/admin/breeding.php
+++ b/public/views/admin/breeding.php
@@ -1,0 +1,308 @@
+<?php include __DIR__ . '/../partials/header.php'; ?>
+<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
+<h1>Zuchtplanung</h1>
+<?php include __DIR__ . '/nav.php'; ?>
+<?php if ($flashSuccess): ?>
+    <div class="alert alert-success" role="status" aria-live="polite"><?= htmlspecialchars($flashSuccess) ?></div>
+<?php endif; ?>
+<?php if ($flashError): ?>
+    <div class="alert alert-error" role="alert" aria-live="assertive"><?= htmlspecialchars($flashError) ?></div>
+<?php endif; ?>
+<?php
+    $currentUser = current_user();
+    $ownedAnimals = [];
+    $otherAnimals = [];
+    foreach ($animals as $animalOption) {
+        if ($currentUser && (int)($animalOption['owner_id'] ?? 0) === (int)$currentUser['id']) {
+            $ownedAnimals[] = $animalOption;
+        } else {
+            $otherAnimals[] = $animalOption;
+        }
+    }
+?>
+<div class="grid" style="grid-template-columns:2fr 1fr;gap:2rem;align-items:start;">
+    <div class="card">
+        <h2>Aktive Pläne</h2>
+        <?php if (empty($breedingPlans)): ?>
+            <p>Es wurden bislang keine Zuchtpläne angelegt.</p>
+        <?php else: ?>
+            <div class="stack">
+                <?php foreach ($breedingPlans as $plan): ?>
+                    <article class="plan-entry">
+                        <header class="plan-entry__header">
+                            <div>
+                                <h3><?= htmlspecialchars($plan['title']) ?></h3>
+                                <p class="text-muted">
+                                    <?= htmlspecialchars($plan['season'] ?: 'Saison offen') ?>
+                                </p>
+                            </div>
+                            <div class="plan-entry__actions">
+                                <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/breeding&edit_plan=<?= (int)$plan['id'] ?>">Bearbeiten</a>
+                                <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/breeding&delete_plan=<?= (int)$plan['id'] ?>" onclick="return confirm('Zuchtplan wirklich löschen?');">Löschen</a>
+                            </div>
+                        </header>
+                        <?php if (!empty($plan['expected_genetics'])): ?>
+                            <div class="plan-entry__section">
+                                <strong>Erwartete Genetik:</strong>
+                                <div class="rich-text-content"><?= render_rich_text($plan['expected_genetics']) ?></div>
+                            </div>
+                        <?php endif; ?>
+                        <?php if (!empty($plan['incubation_notes'])): ?>
+                            <div class="plan-entry__section">
+                                <strong>Inkubation:</strong>
+                                <div class="rich-text-content"><?= render_rich_text($plan['incubation_notes']) ?></div>
+                            </div>
+                        <?php endif; ?>
+                        <?php if (!empty($plan['notes'])): ?>
+                            <div class="rich-text-content"><?= render_rich_text($plan['notes']) ?></div>
+                        <?php endif; ?>
+                        <h4>Elterntiere</h4>
+                        <?php if (empty($plan['parents'])): ?>
+                            <p class="text-muted">Derzeit sind keine Eltern hinterlegt.</p>
+                        <?php else: ?>
+                            <ul class="plan-parents">
+                                <?php foreach ($plan['parents'] as $parent): ?>
+                                    <li>
+                                        <div class="plan-parent__title">
+                                            <strong><?= htmlspecialchars($parent['parent_type'] === 'virtual' ? ($parent['name'] ?: 'Virtuell') : ($parent['animal_name'] ?? $parent['name'] ?? 'Unbenannt')) ?></strong>
+                                            <?php if ($parent['sex']): ?>
+                                                <span class="badge"><?= htmlspecialchars(strtoupper($parent['sex'])) ?></span>
+                                            <?php endif; ?>
+                                        </div>
+                                        <div class="text-muted">
+                                            <?= htmlspecialchars($parent['parent_type'] === 'virtual' ? 'Virtuelles Tier' : 'Bestandstier') ?>
+                                        </div>
+                                        <?php if ($parent['parent_type'] === 'animal' && $parent['animal_species']): ?>
+                                            <div><?= htmlspecialchars($parent['animal_species']) ?></div>
+                                        <?php elseif (!empty($parent['species'])): ?>
+                                            <div><?= htmlspecialchars($parent['species']) ?></div>
+                                        <?php endif; ?>
+                                        <?php if (!empty($parent['animal_genetics']) || !empty($parent['genetics'])): ?>
+                                            <div><strong>Genetik:</strong> <?= htmlspecialchars($parent['animal_genetics'] ?? $parent['genetics']) ?></div>
+                                        <?php endif; ?>
+                                        <?php if (!empty($parent['notes'])): ?>
+                                            <div><?= nl2br(htmlspecialchars($parent['notes'])) ?></div>
+                                        <?php endif; ?>
+                                        <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/breeding&delete_parent=<?= (int)$parent['id'] ?>&plan=<?= (int)$plan['id'] ?>" onclick="return confirm('Elternteil entfernen?');">Entfernen</a>
+                                    </li>
+                                <?php endforeach; ?>
+                            </ul>
+                        <?php endif; ?>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+        <?php endif; ?>
+    </div>
+    <div class="card">
+        <h2><?= $editPlan ? 'Zuchtplan bearbeiten' : 'Neuer Zuchtplan' ?></h2>
+        <form method="post">
+            <input type="hidden" name="form" value="plan">
+            <?php if ($editPlan): ?>
+                <input type="hidden" name="id" value="<?= (int)$editPlan['id'] ?>">
+            <?php endif; ?>
+            <label>Titel
+                <input type="text" name="title" value="<?= htmlspecialchars($editPlan['title'] ?? '') ?>" required>
+            </label>
+            <label>Saison / Jahr
+                <input type="text" name="season" value="<?= htmlspecialchars($editPlan['season'] ?? '') ?>" placeholder="z.B. 2024/2025">
+            </label>
+            <label>Erwartete Genetik
+                <textarea name="expected_genetics" class="rich-text"><?= htmlspecialchars($editPlan['expected_genetics'] ?? '') ?></textarea>
+            </label>
+            <label>Inkubationsnotizen
+                <textarea name="incubation_notes" class="rich-text"><?= htmlspecialchars($editPlan['incubation_notes'] ?? '') ?></textarea>
+            </label>
+            <label>Allgemeine Notizen
+                <textarea name="notes" class="rich-text"><?= htmlspecialchars($editPlan['notes'] ?? '') ?></textarea>
+            </label>
+            <button type="submit">Zuchtplan speichern</button>
+        </form>
+        <?php if (!empty($breedingPlans)): ?>
+            <hr style="margin:2rem 0;opacity:0.3;">
+            <h3>Elterntier hinzufügen</h3>
+            <form method="post">
+                <input type="hidden" name="form" value="parent">
+                <label>Zuchtplan
+                    <select name="plan_id" required>
+                        <?php foreach ($breedingPlans as $planOption): ?>
+                            <option value="<?= (int)$planOption['id'] ?>" <?= (($editPlan['id'] ?? 0) == $planOption['id']) ? 'selected' : '' ?>><?= htmlspecialchars($planOption['title']) ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </label>
+                <label>Eltern-Typ
+                    <select name="parent_type">
+                        <option value="animal">Tier aus Bestand</option>
+                        <option value="virtual">Virtuelles Tier</option>
+                    </select>
+                </label>
+            <label>Tier aus Bestand
+                <select name="animal_id">
+                    <option value="">— auswählen —</option>
+                    <?php if (!empty($ownedAnimals)): ?>
+                        <optgroup label="Eigene Tiere">
+                            <?php foreach ($ownedAnimals as $animal): ?>
+                                <option value="<?= (int)$animal['id'] ?>"><?= htmlspecialchars($animal['name']) ?> (<?= htmlspecialchars($animal['species']) ?>)</option>
+                            <?php endforeach; ?>
+                        </optgroup>
+                    <?php endif; ?>
+                    <?php if (!empty($otherAnimals)): ?>
+                        <optgroup label="Bestand (Team)">
+                            <?php foreach ($otherAnimals as $animal): ?>
+                                <option value="<?= (int)$animal['id'] ?>"><?= htmlspecialchars($animal['name']) ?> (<?= htmlspecialchars($animal['species']) ?>)</option>
+                            <?php endforeach; ?>
+                        </optgroup>
+                    <?php endif; ?>
+                </select>
+            </label>
+                <label>Name (für virtuelle Eltern)
+                    <input type="text" name="name" value="">
+                </label>
+                <label>Geschlecht (m/w)
+                    <input type="text" name="sex" value="">
+                </label>
+                <label>Art / Lokalität
+                    <input type="text" name="species" value="">
+                </label>
+            <label>Genetik
+                    <textarea name="genetics" class="rich-text"></textarea>
+            </label>
+            <label>Notizen
+                    <textarea name="notes" class="rich-text"></textarea>
+            </label>
+                <button type="submit">Elternteil speichern</button>
+            </form>
+            <hr style="margin:2rem 0;opacity:0.3;">
+            <h3>Verpaarung anlegen</h3>
+            <form method="post" data-breeding-pair-form>
+                <input type="hidden" name="form" value="pair">
+                <label>Zuchtplan
+                    <select name="pair_plan_id" required>
+                        <?php foreach ($breedingPlans as $planOption): ?>
+                            <option value="<?= (int)$planOption['id'] ?>" <?= (($editPlan['id'] ?? 0) == $planOption['id']) ? 'selected' : '' ?>><?= htmlspecialchars($planOption['title']) ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </label>
+                <div class="pair-grid">
+                    <fieldset class="parent-block">
+                        <legend>Elternteil A</legend>
+                        <label>Quelle
+                            <select name="parent_a_type" data-parent-type="a">
+                                <option value="animal">Tier aus dem Bestand</option>
+                                <option value="virtual">Virtuelles Tier</option>
+                            </select>
+                        </label>
+                        <div class="parent-block__group" data-parent-group="a" data-group-type="animal">
+                            <label>Tier auswählen
+                                <select name="parent_a_animal_id">
+                                    <option value="">— auswählen —</option>
+                                    <?php if (!empty($ownedAnimals)): ?>
+                                        <optgroup label="Eigene Tiere">
+                                            <?php foreach ($ownedAnimals as $animal): ?>
+                                                <option value="<?= (int)$animal['id'] ?>"><?= htmlspecialchars($animal['name']) ?> (<?= htmlspecialchars($animal['species']) ?>)</option>
+                                            <?php endforeach; ?>
+                                        </optgroup>
+                                    <?php endif; ?>
+                                    <?php if (!empty($otherAnimals)): ?>
+                                        <optgroup label="Bestand (Team)">
+                                            <?php foreach ($otherAnimals as $animal): ?>
+                                                <option value="<?= (int)$animal['id'] ?>"><?= htmlspecialchars($animal['name']) ?> (<?= htmlspecialchars($animal['species']) ?>)</option>
+                                            <?php endforeach; ?>
+                                        </optgroup>
+                                    <?php endif; ?>
+                                </select>
+                            </label>
+                        </div>
+                        <div class="parent-block__group" data-parent-group="a" data-group-type="virtual" hidden>
+                            <label>Name
+                                <input type="text" name="parent_a_name">
+                            </label>
+                            <label>Geschlecht (m/w)
+                                <input type="text" name="parent_a_sex">
+                            </label>
+                            <label>Art / Lokalität
+                                <input type="text" name="parent_a_species">
+                            </label>
+                            <label>Genetik
+                                <textarea name="parent_a_genetics" class="rich-text"></textarea>
+                            </label>
+                            <label>Notizen
+                                <textarea name="parent_a_notes" class="rich-text"></textarea>
+                            </label>
+                        </div>
+                    </fieldset>
+                    <fieldset class="parent-block">
+                        <legend>Elternteil B</legend>
+                        <label>Quelle
+                            <select name="parent_b_type" data-parent-type="b">
+                                <option value="animal">Tier aus dem Bestand</option>
+                                <option value="virtual">Virtuelles Tier</option>
+                            </select>
+                        </label>
+                        <div class="parent-block__group" data-parent-group="b" data-group-type="animal">
+                            <label>Tier auswählen
+                                <select name="parent_b_animal_id">
+                                    <option value="">— auswählen —</option>
+                                    <?php if (!empty($ownedAnimals)): ?>
+                                        <optgroup label="Eigene Tiere">
+                                            <?php foreach ($ownedAnimals as $animal): ?>
+                                                <option value="<?= (int)$animal['id'] ?>"><?= htmlspecialchars($animal['name']) ?> (<?= htmlspecialchars($animal['species']) ?>)</option>
+                                            <?php endforeach; ?>
+                                        </optgroup>
+                                    <?php endif; ?>
+                                    <?php if (!empty($otherAnimals)): ?>
+                                        <optgroup label="Bestand (Team)">
+                                            <?php foreach ($otherAnimals as $animal): ?>
+                                                <option value="<?= (int)$animal['id'] ?>"><?= htmlspecialchars($animal['name']) ?> (<?= htmlspecialchars($animal['species']) ?>)</option>
+                                            <?php endforeach; ?>
+                                        </optgroup>
+                                    <?php endif; ?>
+                                </select>
+                            </label>
+                        </div>
+                        <div class="parent-block__group" data-parent-group="b" data-group-type="virtual" hidden>
+                            <label>Name
+                                <input type="text" name="parent_b_name">
+                            </label>
+                            <label>Geschlecht (m/w)
+                                <input type="text" name="parent_b_sex">
+                            </label>
+                            <label>Art / Lokalität
+                                <input type="text" name="parent_b_species">
+                            </label>
+                            <label>Genetik
+                                <textarea name="parent_b_genetics" class="rich-text"></textarea>
+                            </label>
+                            <label>Notizen
+                                <textarea name="parent_b_notes" class="rich-text"></textarea>
+                            </label>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit">Verpaarung speichern</button>
+            </form>
+        <?php endif; ?>
+</div>
+</div>
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const form = document.querySelector('[data-breeding-pair-form]');
+    if (!form) {
+        return;
+    }
+    function toggleGroups(parentKey, type) {
+        form.querySelectorAll('[data-parent-group="' + parentKey + '"]').forEach(function (group) {
+            group.hidden = group.getAttribute('data-group-type') !== type;
+        });
+    }
+    form.querySelectorAll('[data-parent-type]').forEach(function (select) {
+        const parentKey = select.getAttribute('data-parent-type');
+        toggleGroups(parentKey, select.value);
+        select.addEventListener('change', function () {
+            toggleGroups(parentKey, select.value);
+        });
+    });
+});
+</script>
+</section>
+<?php include __DIR__ . '/../partials/footer.php'; ?>
+

--- a/public/views/admin/care.php
+++ b/public/views/admin/care.php
@@ -1,17 +1,28 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
-<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
-<h1>Pflegeleitfaden</h1>
+<section class="admin-shell">
+<header class="admin-page-header">
+    <div>
+        <h1 class="admin-title">Pflegeleitfaden</h1>
+        <p class="admin-subtitle">Sammle und strukturier Wissen für gesunde Pogona vitticeps – klar, leichtgewichtig und jederzeit abrufbar.</p>
+    </div>
+    <div class="admin-meta">
+        <span class="badge">Wissensarchiv</span>
+        <span><?= count($careArticles) ?> Artikel</span>
+    </div>
+</header>
 <?php include __DIR__ . '/nav.php'; ?>
+<div class="admin-section">
 <?php if ($flashSuccess): ?>
     <div class="alert alert-success" role="status" aria-live="polite"><?= htmlspecialchars($flashSuccess) ?></div>
 <?php endif; ?>
 <?php if ($flashError): ?>
     <div class="alert alert-error" role="alert" aria-live="assertive"><?= htmlspecialchars($flashError) ?></div>
 <?php endif; ?>
-<div class="grid" style="grid-template-columns:2fr 1fr;gap:2rem;align-items:start;">
+<div class="admin-layout">
     <div class="card">
         <h2>Artikelübersicht</h2>
-        <table class="table">
+        <div class="table-responsive">
+            <table class="table">
             <thead>
                 <tr>
                     <th>Titel</th>
@@ -39,7 +50,8 @@
                     </tr>
                 <?php endforeach; ?>
             </tbody>
-        </table>
+            </table>
+        </div>
     </div>
     <div class="card">
         <h2><?= $editArticle ? 'Artikel bearbeiten' : 'Neuer Artikel' ?></h2>
@@ -59,12 +71,14 @@
             <label>Inhalt
                 <textarea name="content" class="rich-text" required><?= htmlspecialchars($editArticle['content'] ?? '') ?></textarea>
             </label>
-            <label style="display:flex;align-items:center;gap:0.5rem;">
-                <input type="checkbox" name="is_published" value="1" <?= !empty($editArticle['is_published']) ? 'checked' : '' ?>> Veröffentlichen
+            <label class="form-switch">
+                <input type="checkbox" name="is_published" value="1" <?= !empty($editArticle['is_published']) ? 'checked' : '' ?>>
+                <span>Veröffentlichen</span>
             </label>
             <button type="submit">Speichern</button>
         </form>
     </div>
+</div>
 </div>
 </section>
 <?php include __DIR__ . '/../partials/footer.php'; ?>

--- a/public/views/admin/care.php
+++ b/public/views/admin/care.php
@@ -1,0 +1,71 @@
+<?php include __DIR__ . '/../partials/header.php'; ?>
+<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
+<h1>Pflegeleitfaden</h1>
+<?php include __DIR__ . '/nav.php'; ?>
+<?php if ($flashSuccess): ?>
+    <div class="alert alert-success" role="status" aria-live="polite"><?= htmlspecialchars($flashSuccess) ?></div>
+<?php endif; ?>
+<?php if ($flashError): ?>
+    <div class="alert alert-error" role="alert" aria-live="assertive"><?= htmlspecialchars($flashError) ?></div>
+<?php endif; ?>
+<div class="grid" style="grid-template-columns:2fr 1fr;gap:2rem;align-items:start;">
+    <div class="card">
+        <h2>Artikelübersicht</h2>
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>Titel</th>
+                    <th>Slug</th>
+                    <th>Status</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($careArticles as $article): ?>
+                    <tr>
+                        <td><?= htmlspecialchars($article['title']) ?></td>
+                        <td><?= htmlspecialchars($article['slug']) ?></td>
+                        <td>
+                            <?php if ($article['is_published']): ?>
+                                <span class="badge">veröffentlicht</span>
+                            <?php else: ?>
+                                <span class="badge">Entwurf</span>
+                            <?php endif; ?>
+                        </td>
+                        <td>
+                            <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/care&edit=<?= (int)$article['id'] ?>">Bearbeiten</a>
+                            <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/care&delete=<?= (int)$article['id'] ?>" onclick="return confirm('Artikel wirklich löschen?');">Löschen</a>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+    <div class="card">
+        <h2><?= $editArticle ? 'Artikel bearbeiten' : 'Neuer Artikel' ?></h2>
+        <form method="post">
+            <?php if ($editArticle): ?>
+                <input type="hidden" name="id" value="<?= (int)$editArticle['id'] ?>">
+            <?php endif; ?>
+            <label>Titel
+                <input type="text" name="title" value="<?= htmlspecialchars($editArticle['title'] ?? '') ?>" required>
+            </label>
+            <label>Slug (optional)
+                <input type="text" name="slug" value="<?= htmlspecialchars($editArticle['slug'] ?? '') ?>">
+            </label>
+            <label>Kurzbeschreibung
+                <textarea name="summary" class="rich-text" rows="4"><?= htmlspecialchars($editArticle['summary'] ?? '') ?></textarea>
+            </label>
+            <label>Inhalt
+                <textarea name="content" class="rich-text" required><?= htmlspecialchars($editArticle['content'] ?? '') ?></textarea>
+            </label>
+            <label style="display:flex;align-items:center;gap:0.5rem;">
+                <input type="checkbox" name="is_published" value="1" <?= !empty($editArticle['is_published']) ? 'checked' : '' ?>> Veröffentlichen
+            </label>
+            <button type="submit">Speichern</button>
+        </form>
+    </div>
+</div>
+</section>
+<?php include __DIR__ . '/../partials/footer.php'; ?>
+

--- a/public/views/admin/dashboard.php
+++ b/public/views/admin/dashboard.php
@@ -1,4 +1,5 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
+<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
 <h1>Admin-Dashboard</h1>
 <?php include __DIR__ . '/nav.php'; ?>
 <div class="grid cards">
@@ -13,6 +14,30 @@
     <div class="card">
         <h3>Neue Anfragen</h3>
         <p><?= count($inquiries) ?> Nachrichten</p>
+    </div>
+    <div class="card">
+        <h3>Seiten</h3>
+        <p><?= count($pages) ?> Einträge</p>
+    </div>
+    <div class="card">
+        <h3>News</h3>
+        <p><?= count($newsPosts) ?> Beiträge</p>
+    </div>
+    <div class="card">
+        <h3>Zuchtpläne</h3>
+        <p><?= count($breedingPlans) ?> Projekte</p>
+    </div>
+    <div class="card">
+        <h3>Pflegeartikel</h3>
+        <p><?= count($careArticles) ?> Artikel</p>
+    </div>
+    <div class="card">
+        <h3>Genetische Arten</h3>
+        <p><?= isset($geneticSpecies) ? count($geneticSpecies) : 0 ?> Datensätze</p>
+    </div>
+    <div class="card">
+        <h3>Gene</h3>
+        <p><?= isset($geneticGenes) ? count($geneticGenes) : 0 ?> Einträge</p>
     </div>
 </div>
 
@@ -44,5 +69,6 @@
             </table>
         <?php endif; ?>
     </div>
+</section>
 </section>
 <?php include __DIR__ . '/../partials/footer.php'; ?>

--- a/public/views/admin/dashboard.php
+++ b/public/views/admin/dashboard.php
@@ -1,6 +1,15 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
-<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
-<h1>Admin-Dashboard</h1>
+<section class="admin-shell">
+<header class="admin-page-header">
+    <div>
+        <h1 class="admin-title">Admin-Dashboard</h1>
+        <p class="admin-subtitle">Behalte jedes Detail deines digitalen Terrariums im Blick – von aktiven Bartagamen bis zu den neuesten Anfragen.</p>
+    </div>
+    <div class="admin-meta">
+        <span class="badge">Pogona Pulse</span>
+        <span><?= count($animals) ?> Tiere aktiv</span>
+    </div>
+</header>
 <?php include __DIR__ . '/nav.php'; ?>
 <div class="grid cards">
     <div class="card">
@@ -40,14 +49,14 @@
         <p><?= isset($geneticGenes) ? count($geneticGenes) : 0 ?> Einträge</p>
     </div>
 </div>
-
-<section style="margin-top:2rem;">
+<section class="admin-section">
     <h2>Letzte Anfragen</h2>
     <div class="card">
         <?php if (empty($inquiries)): ?>
             Keine Anfragen vorhanden.
         <?php else: ?>
-            <table class="table">
+            <div class="table-responsive">
+                <table class="table">
                 <thead>
                     <tr>
                         <th>Datum</th>
@@ -66,7 +75,8 @@
                         </tr>
                     <?php endforeach; ?>
                 </tbody>
-            </table>
+                </table>
+            </div>
         <?php endif; ?>
     </div>
 </section>

--- a/public/views/admin/genetics.php
+++ b/public/views/admin/genetics.php
@@ -1,0 +1,195 @@
+<?php include __DIR__ . '/../partials/header.php'; ?>
+<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
+<h1>Genetikverwaltung</h1>
+<?php include __DIR__ . '/nav.php'; ?>
+<?php if ($flashSuccess): ?>
+    <div class="alert alert-success" role="status" aria-live="polite"><?= htmlspecialchars($flashSuccess) ?></div>
+<?php endif; ?>
+<?php if ($flashError): ?>
+    <div class="alert alert-error" role="alert" aria-live="assertive"><?= htmlspecialchars($flashError) ?></div>
+<?php endif; ?>
+
+<div class="grid" style="grid-template-columns:2fr 1fr;gap:2rem;align-items:start;">
+    <div class="card">
+        <h2>Genetische Arten</h2>
+        <?php if (empty($speciesList)): ?>
+            <p>Noch keine Arten hinterlegt.</p>
+        <?php else: ?>
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Wissenschaftlich</th>
+                        <th>Slug</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($speciesList as $species): ?>
+                        <tr>
+                            <td><?= htmlspecialchars($species['name']) ?></td>
+                            <td><?= htmlspecialchars($species['scientific_name'] ?? '') ?></td>
+                            <td><?= htmlspecialchars($species['slug']) ?></td>
+                            <td style="display:flex;gap:0.5rem;flex-wrap:wrap;">
+                                <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/genetics&amp;species=<?= urlencode($species['slug']) ?>">Anzeigen</a>
+                                <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/genetics&amp;edit_species=<?= (int)$species['id'] ?>">Bearbeiten</a>
+                                <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/genetics&amp;delete_species=<?= (int)$species['id'] ?>" onclick="return confirm('Art wirklich löschen? Alle zugehörigen Gene werden entfernt.');">Löschen</a>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        <?php endif; ?>
+    </div>
+    <div class="card">
+        <h2><?= $editSpecies ? 'Art bearbeiten' : 'Neue Art' ?></h2>
+        <form method="post">
+            <input type="hidden" name="form_type" value="species">
+            <?php if ($editSpecies): ?>
+                <input type="hidden" name="id" value="<?= (int)$editSpecies['id'] ?>">
+            <?php endif; ?>
+            <label>Name
+                <input type="text" name="name" value="<?= htmlspecialchars($editSpecies['name'] ?? '') ?>" required>
+            </label>
+            <label>Slug (optional)
+                <input type="text" name="slug" value="<?= htmlspecialchars($editSpecies['slug'] ?? '') ?>" placeholder="automatisch">
+            </label>
+            <label>Wissenschaftlicher Name
+                <input type="text" name="scientific_name" value="<?= htmlspecialchars($editSpecies['scientific_name'] ?? '') ?>">
+            </label>
+            <label>Beschreibung
+                <textarea name="description" rows="5"><?= htmlspecialchars($editSpecies['description'] ?? '') ?></textarea>
+            </label>
+            <button type="submit">Speichern</button>
+        </form>
+    </div>
+</div>
+
+<section style="margin-top:3rem;">
+    <h2>Gene verwalten</h2>
+    <?php if (empty($speciesList)): ?>
+        <div class="card">
+            <p>Lege zuerst eine Art an, um Gene zu verwalten.</p>
+        </div>
+    <?php else: ?>
+        <div class="card" style="margin-bottom:1.5rem;">
+            <form method="get" style="display:flex;gap:1rem;align-items:flex-end;flex-wrap:wrap;">
+                <input type="hidden" name="route" value="admin/genetics">
+                <label>Art auswählen
+                    <select name="species" onchange="this.form.submit()">
+                        <?php foreach ($speciesList as $species): ?>
+                            <option value="<?= htmlspecialchars($species['slug']) ?>" <?= ($selectedSpeciesSlug === $species['slug']) ? 'selected' : '' ?>><?= htmlspecialchars($species['name']) ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </label>
+                <noscript>
+                    <button type="submit">Wechseln</button>
+                </noscript>
+            </form>
+            <?php if ($selectedSpecies): ?>
+                <p class="text-muted">Aktiv: <?= htmlspecialchars($selectedSpecies['name']) ?><?= $selectedSpecies['scientific_name'] ? ' (' . htmlspecialchars($selectedSpecies['scientific_name']) . ')' : '' ?></p>
+                <?php if (!empty($selectedSpecies['description'])): ?>
+                    <div class="rich-text-content" style="margin-top:0.75rem;">
+                        <?= render_rich_text($selectedSpecies['description']) ?>
+                    </div>
+                <?php endif; ?>
+            <?php endif; ?>
+        </div>
+
+        <div class="grid" style="grid-template-columns:2fr 1fr;gap:2rem;align-items:start;">
+            <div class="card">
+                <h3>Gene der Art</h3>
+                <?php if (empty($genes)): ?>
+                    <p>Noch keine Gene angelegt.</p>
+                <?php else: ?>
+                    <table class="table">
+                        <thead>
+                            <tr>
+                                <th>Name</th>
+                                <th>Kürzel</th>
+                                <th>Vererbung</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php foreach ($genes as $gene): ?>
+                                <tr>
+                                    <td>
+                                        <strong><?= htmlspecialchars($gene['name']) ?></strong><br>
+                                        <small class="text-muted">Slug: <?= htmlspecialchars($gene['slug']) ?></small>
+                                    </td>
+                                    <td><?= htmlspecialchars($gene['shorthand'] ?? '') ?></td>
+                                    <td>
+                                        <?php
+                                            $modeLabels = [
+                                                'recessive' => 'rezessiv',
+                                                'dominant' => 'dominant',
+                                                'incomplete_dominant' => 'inkomplett dominant',
+                                            ];
+                                        ?>
+                                        <?= htmlspecialchars($modeLabels[$gene['inheritance_mode']] ?? $gene['inheritance_mode']) ?>
+                                    </td>
+                                    <td style="display:flex;gap:0.5rem;flex-wrap:wrap;">
+                                        <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/genetics&amp;edit_gene=<?= (int)$gene['id'] ?>">Bearbeiten</a>
+                                        <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/genetics&amp;delete_gene=<?= (int)$gene['id'] ?>" onclick="return confirm('Gen wirklich löschen?');">Löschen</a>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                <?php endif; ?>
+            </div>
+            <div class="card">
+                <h3><?= $editGene ? 'Gen bearbeiten' : 'Neues Gen' ?></h3>
+                <?php if (!$selectedSpecies): ?>
+                    <p>Bitte zuerst eine Art auswählen.</p>
+                <?php else: ?>
+                    <form method="post">
+                        <input type="hidden" name="form_type" value="gene">
+                        <input type="hidden" name="species_id" value="<?= (int)$selectedSpecies['id'] ?>">
+                        <input type="hidden" name="species_slug" value="<?= htmlspecialchars($selectedSpecies['slug']) ?>">
+                        <?php if ($editGene): ?>
+                            <input type="hidden" name="id" value="<?= (int)$editGene['id'] ?>">
+                        <?php endif; ?>
+                        <label>Name
+                            <input type="text" name="name" value="<?= htmlspecialchars($editGene['name'] ?? '') ?>" required>
+                        </label>
+                        <label>Slug (optional)
+                            <input type="text" name="slug" value="<?= htmlspecialchars($editGene['slug'] ?? '') ?>" placeholder="automatisch">
+                        </label>
+                        <label>Kürzel
+                            <input type="text" name="shorthand" value="<?= htmlspecialchars($editGene['shorthand'] ?? '') ?>">
+                        </label>
+                        <label>Vererbung
+                            <?php $currentMode = $editGene['inheritance_mode'] ?? 'recessive'; ?>
+                            <select name="inheritance_mode">
+                                <option value="recessive" <?= ($currentMode === 'recessive') ? 'selected' : '' ?>>rezessiv</option>
+                                <option value="dominant" <?= ($currentMode === 'dominant') ? 'selected' : '' ?>>dominant</option>
+                                <option value="incomplete_dominant" <?= ($currentMode === 'incomplete_dominant') ? 'selected' : '' ?>>inkomplett dominant</option>
+                            </select>
+                        </label>
+                        <label>Label (Normalform)
+                            <input type="text" name="normal_label" value="<?= htmlspecialchars($editGene['normal_label'] ?? '') ?>" placeholder="z.B. Wildtyp">
+                        </label>
+                        <label>Label (heterozygot)
+                            <input type="text" name="heterozygous_label" value="<?= htmlspecialchars($editGene['heterozygous_label'] ?? '') ?>" placeholder="z.B. het Albino">
+                        </label>
+                        <label>Label (homozygot)
+                            <input type="text" name="homozygous_label" value="<?= htmlspecialchars($editGene['homozygous_label'] ?? '') ?>" placeholder="z.B. Albino">
+                        </label>
+                        <label>Reihenfolge
+                            <input type="number" name="display_order" value="<?= htmlspecialchars((string)($editGene['display_order'] ?? 0)) ?>">
+                        </label>
+                        <label>Beschreibung
+                            <textarea name="description" rows="4"><?= htmlspecialchars($editGene['description'] ?? '') ?></textarea>
+                        </label>
+                        <button type="submit">Speichern</button>
+                    </form>
+                <?php endif; ?>
+            </div>
+        </div>
+    <?php endif; ?>
+</section>
+
+</section>
+<?php include __DIR__ . '/../partials/footer.php'; ?>

--- a/public/views/admin/genetics.php
+++ b/public/views/admin/genetics.php
@@ -1,7 +1,17 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
-<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
-<h1>Genetikverwaltung</h1>
+<section class="admin-shell">
+<header class="admin-page-header">
+    <div>
+        <h1 class="admin-title">Genetikverwaltung</h1>
+        <p class="admin-subtitle">Behalte komplexe Morph-Kombinationen und Arten im Griff – optimiert für präzise Pogona-Zuchtplanung.</p>
+    </div>
+    <div class="admin-meta">
+        <span class="badge">Genetik-Matrix</span>
+        <span><?= count($speciesList) ?> Arten · <?= count($genes ?? []) ?> Gene</span>
+    </div>
+</header>
 <?php include __DIR__ . '/nav.php'; ?>
+<div class="admin-section">
 <?php if ($flashSuccess): ?>
     <div class="alert alert-success" role="status" aria-live="polite"><?= htmlspecialchars($flashSuccess) ?></div>
 <?php endif; ?>
@@ -9,36 +19,38 @@
     <div class="alert alert-error" role="alert" aria-live="assertive"><?= htmlspecialchars($flashError) ?></div>
 <?php endif; ?>
 
-<div class="grid" style="grid-template-columns:2fr 1fr;gap:2rem;align-items:start;">
+<div class="admin-layout">
     <div class="card">
         <h2>Genetische Arten</h2>
         <?php if (empty($speciesList)): ?>
             <p>Noch keine Arten hinterlegt.</p>
         <?php else: ?>
-            <table class="table">
-                <thead>
-                    <tr>
-                        <th>Name</th>
-                        <th>Wissenschaftlich</th>
-                        <th>Slug</th>
-                        <th></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <?php foreach ($speciesList as $species): ?>
+            <div class="table-responsive">
+                <table class="table">
+                    <thead>
                         <tr>
-                            <td><?= htmlspecialchars($species['name']) ?></td>
-                            <td><?= htmlspecialchars($species['scientific_name'] ?? '') ?></td>
-                            <td><?= htmlspecialchars($species['slug']) ?></td>
-                            <td style="display:flex;gap:0.5rem;flex-wrap:wrap;">
-                                <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/genetics&amp;species=<?= urlencode($species['slug']) ?>">Anzeigen</a>
-                                <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/genetics&amp;edit_species=<?= (int)$species['id'] ?>">Bearbeiten</a>
-                                <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/genetics&amp;delete_species=<?= (int)$species['id'] ?>" onclick="return confirm('Art wirklich löschen? Alle zugehörigen Gene werden entfernt.');">Löschen</a>
-                            </td>
+                            <th>Name</th>
+                            <th>Wissenschaftlich</th>
+                            <th>Slug</th>
+                            <th></th>
                         </tr>
-                    <?php endforeach; ?>
-                </tbody>
-            </table>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($speciesList as $species): ?>
+                            <tr>
+                                <td><?= htmlspecialchars($species['name']) ?></td>
+                                <td><?= htmlspecialchars($species['scientific_name'] ?? '') ?></td>
+                                <td><?= htmlspecialchars($species['slug']) ?></td>
+                                <td class="table-actions">
+                                    <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/genetics&amp;species=<?= urlencode($species['slug']) ?>">Anzeigen</a>
+                                    <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/genetics&amp;edit_species=<?= (int)$species['id'] ?>">Bearbeiten</a>
+                                    <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/genetics&amp;delete_species=<?= (int)$species['id'] ?>" onclick="return confirm('Art wirklich löschen? Alle zugehörigen Gene werden entfernt.');">Löschen</a>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
         <?php endif; ?>
     </div>
     <div class="card">
@@ -65,15 +77,17 @@
     </div>
 </div>
 
-<section style="margin-top:3rem;">
+</div>
+
+<section class="admin-section">
     <h2>Gene verwalten</h2>
     <?php if (empty($speciesList)): ?>
         <div class="card">
             <p>Lege zuerst eine Art an, um Gene zu verwalten.</p>
         </div>
     <?php else: ?>
-        <div class="card" style="margin-bottom:1.5rem;">
-            <form method="get" style="display:flex;gap:1rem;align-items:flex-end;flex-wrap:wrap;">
+        <div class="card">
+            <form method="get" class="admin-toolbar">
                 <input type="hidden" name="route" value="admin/genetics">
                 <label>Art auswählen
                     <select name="species" onchange="this.form.submit()">
@@ -89,54 +103,56 @@
             <?php if ($selectedSpecies): ?>
                 <p class="text-muted">Aktiv: <?= htmlspecialchars($selectedSpecies['name']) ?><?= $selectedSpecies['scientific_name'] ? ' (' . htmlspecialchars($selectedSpecies['scientific_name']) . ')' : '' ?></p>
                 <?php if (!empty($selectedSpecies['description'])): ?>
-                    <div class="rich-text-content" style="margin-top:0.75rem;">
+                    <div class="rich-text-content gene-legend">
                         <?= render_rich_text($selectedSpecies['description']) ?>
                     </div>
                 <?php endif; ?>
             <?php endif; ?>
         </div>
 
-        <div class="grid" style="grid-template-columns:2fr 1fr;gap:2rem;align-items:start;">
+        <div class="admin-layout">
             <div class="card">
                 <h3>Gene der Art</h3>
                 <?php if (empty($genes)): ?>
                     <p>Noch keine Gene angelegt.</p>
                 <?php else: ?>
-                    <table class="table">
-                        <thead>
-                            <tr>
-                                <th>Name</th>
-                                <th>Kürzel</th>
-                                <th>Vererbung</th>
-                                <th></th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <?php foreach ($genes as $gene): ?>
+                    <div class="table-responsive">
+                        <table class="table">
+                            <thead>
                                 <tr>
-                                    <td>
-                                        <strong><?= htmlspecialchars($gene['name']) ?></strong><br>
-                                        <small class="text-muted">Slug: <?= htmlspecialchars($gene['slug']) ?></small>
-                                    </td>
-                                    <td><?= htmlspecialchars($gene['shorthand'] ?? '') ?></td>
-                                    <td>
-                                        <?php
-                                            $modeLabels = [
-                                                'recessive' => 'rezessiv',
-                                                'dominant' => 'dominant',
-                                                'incomplete_dominant' => 'inkomplett dominant',
-                                            ];
-                                        ?>
-                                        <?= htmlspecialchars($modeLabels[$gene['inheritance_mode']] ?? $gene['inheritance_mode']) ?>
-                                    </td>
-                                    <td style="display:flex;gap:0.5rem;flex-wrap:wrap;">
-                                        <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/genetics&amp;edit_gene=<?= (int)$gene['id'] ?>">Bearbeiten</a>
-                                        <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/genetics&amp;delete_gene=<?= (int)$gene['id'] ?>" onclick="return confirm('Gen wirklich löschen?');">Löschen</a>
-                                    </td>
+                                    <th>Name</th>
+                                    <th>Kürzel</th>
+                                    <th>Vererbung</th>
+                                    <th></th>
                                 </tr>
-                            <?php endforeach; ?>
-                        </tbody>
-                    </table>
+                            </thead>
+                            <tbody>
+                                <?php foreach ($genes as $gene): ?>
+                                    <tr>
+                                        <td>
+                                            <strong><?= htmlspecialchars($gene['name']) ?></strong><br>
+                                            <small class="text-muted">Slug: <?= htmlspecialchars($gene['slug']) ?></small>
+                                        </td>
+                                        <td><?= htmlspecialchars($gene['shorthand'] ?? '') ?></td>
+                                        <td>
+                                            <?php
+                                                $modeLabels = [
+                                                    'recessive' => 'rezessiv',
+                                                    'dominant' => 'dominant',
+                                                    'incomplete_dominant' => 'inkomplett dominant',
+                                                ];
+                                            ?>
+                                            <?= htmlspecialchars($modeLabels[$gene['inheritance_mode']] ?? $gene['inheritance_mode']) ?>
+                                        </td>
+                                        <td class="table-actions">
+                                            <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/genetics&amp;edit_gene=<?= (int)$gene['id'] ?>">Bearbeiten</a>
+                                            <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/genetics&amp;delete_gene=<?= (int)$gene['id'] ?>" onclick="return confirm('Gen wirklich löschen?');">Löschen</a>
+                                        </td>
+                                    </tr>
+                                <?php endforeach; ?>
+                            </tbody>
+                        </table>
+                    </div>
                 <?php endif; ?>
             </div>
             <div class="card">

--- a/public/views/admin/inquiries.php
+++ b/public/views/admin/inquiries.php
@@ -1,4 +1,5 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
+<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
 <h1>Anfragen</h1>
 <?php include __DIR__ . '/nav.php'; ?>
 <div class="card">
@@ -31,4 +32,5 @@
         </table>
     <?php endif; ?>
 </div>
+</section>
 <?php include __DIR__ . '/../partials/footer.php'; ?>

--- a/public/views/admin/inquiries.php
+++ b/public/views/admin/inquiries.php
@@ -1,12 +1,23 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
-<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
-<h1>Anfragen</h1>
+<section class="admin-shell">
+<header class="admin-page-header">
+    <div>
+        <h1 class="admin-title">Anfragen</h1>
+        <p class="admin-subtitle">Reagiere auf jede Stimme aus dem Terrarium – fokussiert, schnell und in einem ruhigen Interface.</p>
+    </div>
+    <div class="admin-meta">
+        <span class="badge">Kontaktstrom</span>
+        <span><?= count($inquiries) ?> Nachrichten</span>
+    </div>
+</header>
 <?php include __DIR__ . '/nav.php'; ?>
-<div class="card">
-    <?php if (empty($inquiries)): ?>
-        Keine Nachrichten vorhanden.
-    <?php else: ?>
-        <table class="table">
+<div class="admin-section">
+    <div class="card">
+        <?php if (empty($inquiries)): ?>
+            Keine Nachrichten vorhanden.
+        <?php else: ?>
+        <div class="table-responsive">
+            <table class="table">
             <thead>
                 <tr>
                     <th>Datum</th>
@@ -29,8 +40,10 @@
                     </tr>
                 <?php endforeach; ?>
             </tbody>
-        </table>
-    <?php endif; ?>
+            </table>
+        </div>
+        <?php endif; ?>
+    </div>
 </div>
 </section>
 <?php include __DIR__ . '/../partials/footer.php'; ?>

--- a/public/views/admin/nav.php
+++ b/public/views/admin/nav.php
@@ -1,12 +1,23 @@
-<div class="admin-nav">
-    <a href="<?= BASE_URL ?>/index.php?route=admin/dashboard" class="<?= $currentRoute === 'admin/dashboard' ? 'active' : '' ?>">Übersicht</a>
-    <a href="<?= BASE_URL ?>/index.php?route=admin/animals" class="<?= $currentRoute === 'admin/animals' ? 'active' : '' ?>">Tiere</a>
-    <a href="<?= BASE_URL ?>/index.php?route=admin/adoption" class="<?= $currentRoute === 'admin/adoption' ? 'active' : '' ?>">Tierabgabe</a>
-    <a href="<?= BASE_URL ?>/index.php?route=admin/inquiries" class="<?= $currentRoute === 'admin/inquiries' ? 'active' : '' ?>">Anfragen</a>
+<?php
+    $linkBase = 'inline-flex items-center gap-1 rounded-full border border-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200 transition hover:border-brand-400 hover:bg-brand-500/10 hover:text-brand-100';
+    $linkActive = 'inline-flex items-center gap-1 rounded-full border border-brand-400 bg-brand-500/20 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-brand-100 shadow-glow';
+?>
+<nav class="mt-6 flex flex-wrap gap-2">
+    <a href="<?= BASE_URL ?>/index.php?route=admin/dashboard" class="<?= $currentRoute === 'admin/dashboard' ? $linkActive : $linkBase ?>">Übersicht</a>
+    <a href="<?= BASE_URL ?>/index.php?route=admin/animals" class="<?= $currentRoute === 'admin/animals' ? $linkActive : $linkBase ?>">Tiere</a>
+    <?php if (is_authorized('can_manage_animals')): ?>
+        <a href="<?= BASE_URL ?>/index.php?route=admin/breeding" class="<?= $currentRoute === 'admin/breeding' ? $linkActive : $linkBase ?>">Zuchtplanung</a>
+    <?php endif; ?>
+    <a href="<?= BASE_URL ?>/index.php?route=admin/adoption" class="<?= $currentRoute === 'admin/adoption' ? $linkActive : $linkBase ?>">Tierabgabe</a>
+    <a href="<?= BASE_URL ?>/index.php?route=admin/inquiries" class="<?= $currentRoute === 'admin/inquiries' ? $linkActive : $linkBase ?>">Anfragen</a>
     <?php if (is_authorized('can_manage_settings')): ?>
-        <a href="<?= BASE_URL ?>/index.php?route=admin/settings" class="<?= $currentRoute === 'admin/settings' ? 'active' : '' ?>">Einstellungen</a>
+        <a href="<?= BASE_URL ?>/index.php?route=admin/pages" class="<?= $currentRoute === 'admin/pages' ? $linkActive : $linkBase ?>">Seiten</a>
+        <a href="<?= BASE_URL ?>/index.php?route=admin/news" class="<?= $currentRoute === 'admin/news' ? $linkActive : $linkBase ?>">Neuigkeiten</a>
+        <a href="<?= BASE_URL ?>/index.php?route=admin/care" class="<?= $currentRoute === 'admin/care' ? $linkActive : $linkBase ?>">Pflegeleitfaden</a>
+        <a href="<?= BASE_URL ?>/index.php?route=admin/genetics" class="<?= $currentRoute === 'admin/genetics' ? $linkActive : $linkBase ?>">Genetik</a>
+        <a href="<?= BASE_URL ?>/index.php?route=admin/settings" class="<?= $currentRoute === 'admin/settings' ? $linkActive : $linkBase ?>">Einstellungen</a>
     <?php endif; ?>
     <?php if (current_user()['role'] === 'admin'): ?>
-        <a href="<?= BASE_URL ?>/index.php?route=admin/users" class="<?= $currentRoute === 'admin/users' ? 'active' : '' ?>">Benutzer</a>
+        <a href="<?= BASE_URL ?>/index.php?route=admin/users" class="<?= $currentRoute === 'admin/users' ? $linkActive : $linkBase ?>">Benutzer</a>
     <?php endif; ?>
-</div>
+</nav>

--- a/public/views/admin/nav.php
+++ b/public/views/admin/nav.php
@@ -1,8 +1,8 @@
 <?php
-    $linkBase = 'inline-flex items-center gap-1 rounded-full border border-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200 transition hover:border-brand-400 hover:bg-brand-500/10 hover:text-brand-100';
-    $linkActive = 'inline-flex items-center gap-1 rounded-full border border-brand-400 bg-brand-500/20 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-brand-100 shadow-glow';
+    $linkBase = 'admin-chip';
+    $linkActive = 'admin-chip is-active';
 ?>
-<nav class="mt-6 flex flex-wrap gap-2">
+<nav class="admin-nav" aria-label="Admin-Navigation">
     <a href="<?= BASE_URL ?>/index.php?route=admin/dashboard" class="<?= $currentRoute === 'admin/dashboard' ? $linkActive : $linkBase ?>">Übersicht</a>
     <a href="<?= BASE_URL ?>/index.php?route=admin/animals" class="<?= $currentRoute === 'admin/animals' ? $linkActive : $linkBase ?>">Tiere</a>
     <?php if (is_authorized('can_manage_animals')): ?>

--- a/public/views/admin/news.php
+++ b/public/views/admin/news.php
@@ -1,17 +1,28 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
-<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
-<h1>Neuigkeiten</h1>
+<section class="admin-shell">
+<header class="admin-page-header">
+    <div>
+        <h1 class="admin-title">Neuigkeiten</h1>
+        <p class="admin-subtitle">Veröffentliche Geschichten aus dem Pogona-Habitat mit einem klaren, interaktiven Redaktions-Workspace.</p>
+    </div>
+    <div class="admin-meta">
+        <span class="badge">Storyflow</span>
+        <span><?= count($newsPosts) ?> Beiträge</span>
+    </div>
+</header>
 <?php include __DIR__ . '/nav.php'; ?>
+<div class="admin-section">
 <?php if ($flashSuccess): ?>
     <div class="alert alert-success" role="status" aria-live="polite"><?= htmlspecialchars($flashSuccess) ?></div>
 <?php endif; ?>
 <?php if ($flashError): ?>
     <div class="alert alert-error" role="alert" aria-live="assertive"><?= htmlspecialchars($flashError) ?></div>
 <?php endif; ?>
-<div class="grid" style="grid-template-columns:2fr 1fr;gap:2rem;align-items:start;">
+<div class="admin-layout">
     <div class="card">
         <h2>Veröffentlichte Beiträge</h2>
-        <table class="table">
+        <div class="table-responsive">
+            <table class="table">
             <thead>
                 <tr>
                     <th>Titel</th>
@@ -39,7 +50,8 @@
                     </tr>
                 <?php endforeach; ?>
             </tbody>
-        </table>
+            </table>
+        </div>
     </div>
     <div class="card">
         <h2><?= $editPost ? 'Beitrag bearbeiten' : 'Neuer Beitrag' ?></h2>
@@ -62,12 +74,14 @@
             <label>Veröffentlicht am
                 <input type="datetime-local" name="published_at" value="<?= !empty($editPost['published_at']) ? date('Y-m-d\TH:i', strtotime($editPost['published_at'])) : '' ?>">
             </label>
-            <label style="display:flex;align-items:center;gap:0.5rem;">
-                <input type="checkbox" name="is_published" value="1" <?= !empty($editPost['is_published']) ? 'checked' : '' ?>> Sofort veröffentlichen
+            <label class="form-switch">
+                <input type="checkbox" name="is_published" value="1" <?= !empty($editPost['is_published']) ? 'checked' : '' ?>>
+                <span>Sofort veröffentlichen</span>
             </label>
             <button type="submit">Speichern</button>
         </form>
     </div>
+</div>
 </div>
 </section>
 <?php include __DIR__ . '/../partials/footer.php'; ?>

--- a/public/views/admin/news.php
+++ b/public/views/admin/news.php
@@ -1,0 +1,74 @@
+<?php include __DIR__ . '/../partials/header.php'; ?>
+<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
+<h1>Neuigkeiten</h1>
+<?php include __DIR__ . '/nav.php'; ?>
+<?php if ($flashSuccess): ?>
+    <div class="alert alert-success" role="status" aria-live="polite"><?= htmlspecialchars($flashSuccess) ?></div>
+<?php endif; ?>
+<?php if ($flashError): ?>
+    <div class="alert alert-error" role="alert" aria-live="assertive"><?= htmlspecialchars($flashError) ?></div>
+<?php endif; ?>
+<div class="grid" style="grid-template-columns:2fr 1fr;gap:2rem;align-items:start;">
+    <div class="card">
+        <h2>Veröffentlichte Beiträge</h2>
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>Titel</th>
+                    <th>Status</th>
+                    <th>Veröffentlicht</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($newsPosts as $post): ?>
+                    <tr>
+                        <td><?= htmlspecialchars($post['title']) ?></td>
+                        <td>
+                            <?php if ($post['is_published']): ?>
+                                <span class="badge">online</span>
+                            <?php else: ?>
+                                <span class="badge">Entwurf</span>
+                            <?php endif; ?>
+                        </td>
+                        <td><?= htmlspecialchars($post['published_at'] ?? '—') ?></td>
+                        <td>
+                            <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/news&edit=<?= (int)$post['id'] ?>">Bearbeiten</a>
+                            <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/news&delete=<?= (int)$post['id'] ?>" onclick="return confirm('Beitrag wirklich löschen?');">Löschen</a>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+    <div class="card">
+        <h2><?= $editPost ? 'Beitrag bearbeiten' : 'Neuer Beitrag' ?></h2>
+        <form method="post">
+            <?php if ($editPost): ?>
+                <input type="hidden" name="id" value="<?= (int)$editPost['id'] ?>">
+            <?php endif; ?>
+            <label>Titel
+                <input type="text" name="title" value="<?= htmlspecialchars($editPost['title'] ?? '') ?>" required>
+            </label>
+            <label>Slug (optional)
+                <input type="text" name="slug" value="<?= htmlspecialchars($editPost['slug'] ?? '') ?>">
+            </label>
+            <label>Kurzfassung
+                <textarea name="excerpt" rows="4"><?= htmlspecialchars($editPost['excerpt'] ?? '') ?></textarea>
+            </label>
+            <label>Inhalt
+                <textarea name="content" class="rich-text" required><?= htmlspecialchars($editPost['content'] ?? '') ?></textarea>
+            </label>
+            <label>Veröffentlicht am
+                <input type="datetime-local" name="published_at" value="<?= !empty($editPost['published_at']) ? date('Y-m-d\TH:i', strtotime($editPost['published_at'])) : '' ?>">
+            </label>
+            <label style="display:flex;align-items:center;gap:0.5rem;">
+                <input type="checkbox" name="is_published" value="1" <?= !empty($editPost['is_published']) ? 'checked' : '' ?>> Sofort veröffentlichen
+            </label>
+            <button type="submit">Speichern</button>
+        </form>
+    </div>
+</div>
+</section>
+<?php include __DIR__ . '/../partials/footer.php'; ?>
+

--- a/public/views/admin/pages.php
+++ b/public/views/admin/pages.php
@@ -1,0 +1,107 @@
+<?php include __DIR__ . '/../partials/header.php'; ?>
+<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
+<h1>Seiten verwalten</h1>
+<?php include __DIR__ . '/nav.php'; ?>
+<?php if ($flashSuccess): ?>
+    <div class="alert alert-success" role="status" aria-live="polite"><?= htmlspecialchars($flashSuccess) ?></div>
+<?php endif; ?>
+<?php if ($flashError): ?>
+    <div class="alert alert-error" role="alert" aria-live="assertive"><?= htmlspecialchars($flashError) ?></div>
+<?php endif; ?>
+<?php
+    $pageTitleLookup = [];
+    foreach ($pages as $pageRow) {
+        $pageTitleLookup[$pageRow['id']] = $pageRow['title'];
+    }
+    $hasPagePost = ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['title']) && isset($_POST['content']));
+    $formValues = [
+        'title' => $hasPagePost ? ($_POST['title'] ?? '') : ($editPage['title'] ?? ''),
+        'slug' => $hasPagePost ? ($_POST['slug'] ?? '') : ($editPage['slug'] ?? ''),
+        'content' => $hasPagePost ? ($_POST['content'] ?? '') : ($editPage['content'] ?? ''),
+        'is_published' => $hasPagePost ? !empty($_POST['is_published']) : !empty($editPage['is_published'] ?? null),
+        'show_in_menu' => $hasPagePost ? !empty($_POST['show_in_menu']) : !empty($editPage['show_in_menu'] ?? null),
+        'parent_id' => $hasPagePost ? ($_POST['parent_id'] ?? '') : (($editPage['parent_id'] ?? '') !== '' ? (string)$editPage['parent_id'] : ''),
+    ];
+?>
+<div class="grid" style="grid-template-columns:2fr 1fr;gap:2rem;align-items:start;">
+    <div class="card">
+        <h2>Bestehende Seiten</h2>
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>Titel</th>
+                    <th>Slug</th>
+                    <th>Status</th>
+                    <th>Menü</th>
+                    <th>Übergeordnet</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($pages as $pageItem): ?>
+                    <tr>
+                        <td><?= htmlspecialchars($pageItem['title']) ?></td>
+                        <td><?= htmlspecialchars($pageItem['slug']) ?></td>
+                        <td>
+                            <?php if ($pageItem['is_published']): ?>
+                                <span class="badge">veröffentlicht</span>
+                            <?php else: ?>
+                                <span class="badge">Entwurf</span>
+                            <?php endif; ?>
+                        </td>
+                        <td><?= !empty($pageItem['show_in_menu']) ? 'sichtbar' : 'ausgeblendet' ?></td>
+                        <td>
+                            <?php if (!empty($pageItem['parent_id']) && isset($pageTitleLookup[$pageItem['parent_id']])): ?>
+                                <?= htmlspecialchars($pageTitleLookup[$pageItem['parent_id']]) ?>
+                            <?php else: ?>
+                                <span style="color:var(--text-muted);">Hauptebene</span>
+                            <?php endif; ?>
+                        </td>
+                        <td>
+                            <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/pages&edit=<?= (int)$pageItem['id'] ?>">Bearbeiten</a>
+                            <a class="btn btn-secondary" href="<?= BASE_URL ?>/index.php?route=admin/pages&delete=<?= (int)$pageItem['id'] ?>" onclick="return confirm('Seite wirklich löschen?');">Löschen</a>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+    <div class="card">
+        <h2><?= $editPage ? 'Seite bearbeiten' : 'Neue Seite' ?></h2>
+        <form method="post">
+            <?php if ($editPage): ?>
+                <input type="hidden" name="id" value="<?= (int)$editPage['id'] ?>">
+            <?php endif; ?>
+            <label>Titel
+                <input type="text" name="title" value="<?= htmlspecialchars($formValues['title']) ?>" required>
+            </label>
+            <label>Slug (optional)
+                <input type="text" name="slug" value="<?= htmlspecialchars($formValues['slug']) ?>" placeholder="automatisch aus Titel">
+            </label>
+            <label>Inhalt
+                <textarea name="content" class="rich-text" required><?= htmlspecialchars($formValues['content']) ?></textarea>
+            </label>
+            <label style="display:flex;align-items:center;gap:0.5rem;">
+                <input type="checkbox" name="is_published" value="1" <?= !empty($formValues['is_published']) ? 'checked' : '' ?>> veröffentlichen
+            </label>
+            <label style="display:flex;align-items:center;gap:0.5rem;">
+                <input type="checkbox" name="show_in_menu" value="1" <?= !empty($formValues['show_in_menu']) ? 'checked' : '' ?>> Im Hauptmenü anzeigen
+            </label>
+            <label>Übergeordnete Seite
+                <select name="parent_id">
+                    <option value="">Keine (Hauptebene)</option>
+                    <?php foreach ($pages as $parentOption): ?>
+                        <?php if ($editPage && (int)$parentOption['id'] === (int)$editPage['id']): ?>
+                            <?php continue; ?>
+                        <?php endif; ?>
+                        <option value="<?= (int)$parentOption['id'] ?>" <?= ((string)$parentOption['id'] === (string)$formValues['parent_id']) ? 'selected' : '' ?>><?= htmlspecialchars($parentOption['title']) ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </label>
+            <button type="submit">Speichern</button>
+        </form>
+    </div>
+</div>
+</section>
+<?php include __DIR__ . '/../partials/footer.php'; ?>
+

--- a/public/views/admin/pages.php
+++ b/public/views/admin/pages.php
@@ -1,7 +1,17 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
-<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
-<h1>Seiten verwalten</h1>
+<section class="admin-shell">
+<header class="admin-page-header">
+    <div>
+        <h1 class="admin-title">Seiten verwalten</h1>
+        <p class="admin-subtitle">Strukturiere Inhalte wie ein modularer Felsgarten – klar gegliedert und perfekt für neugierige Bartagamen-Fans.</p>
+    </div>
+    <div class="admin-meta">
+        <span class="badge">Informationsnetz</span>
+        <span><?= count($pages) ?> Seiten</span>
+    </div>
+</header>
 <?php include __DIR__ . '/nav.php'; ?>
+<div class="admin-section">
 <?php if ($flashSuccess): ?>
     <div class="alert alert-success" role="status" aria-live="polite"><?= htmlspecialchars($flashSuccess) ?></div>
 <?php endif; ?>
@@ -23,10 +33,11 @@
         'parent_id' => $hasPagePost ? ($_POST['parent_id'] ?? '') : (($editPage['parent_id'] ?? '') !== '' ? (string)$editPage['parent_id'] : ''),
     ];
 ?>
-<div class="grid" style="grid-template-columns:2fr 1fr;gap:2rem;align-items:start;">
+<div class="admin-layout">
     <div class="card">
         <h2>Bestehende Seiten</h2>
-        <table class="table">
+        <div class="table-responsive">
+            <table class="table">
             <thead>
                 <tr>
                     <th>Titel</th>
@@ -54,7 +65,7 @@
                             <?php if (!empty($pageItem['parent_id']) && isset($pageTitleLookup[$pageItem['parent_id']])): ?>
                                 <?= htmlspecialchars($pageTitleLookup[$pageItem['parent_id']]) ?>
                             <?php else: ?>
-                                <span style="color:var(--text-muted);">Hauptebene</span>
+                                <span class="text-muted">Hauptebene</span>
                             <?php endif; ?>
                         </td>
                         <td>
@@ -64,7 +75,8 @@
                     </tr>
                 <?php endforeach; ?>
             </tbody>
-        </table>
+            </table>
+        </div>
     </div>
     <div class="card">
         <h2><?= $editPage ? 'Seite bearbeiten' : 'Neue Seite' ?></h2>
@@ -81,11 +93,13 @@
             <label>Inhalt
                 <textarea name="content" class="rich-text" required><?= htmlspecialchars($formValues['content']) ?></textarea>
             </label>
-            <label style="display:flex;align-items:center;gap:0.5rem;">
-                <input type="checkbox" name="is_published" value="1" <?= !empty($formValues['is_published']) ? 'checked' : '' ?>> veröffentlichen
+            <label class="form-switch">
+                <input type="checkbox" name="is_published" value="1" <?= !empty($formValues['is_published']) ? 'checked' : '' ?>>
+                <span>veröffentlichen</span>
             </label>
-            <label style="display:flex;align-items:center;gap:0.5rem;">
-                <input type="checkbox" name="show_in_menu" value="1" <?= !empty($formValues['show_in_menu']) ? 'checked' : '' ?>> Im Hauptmenü anzeigen
+            <label class="form-switch">
+                <input type="checkbox" name="show_in_menu" value="1" <?= !empty($formValues['show_in_menu']) ? 'checked' : '' ?>>
+                <span>Im Hauptmenü anzeigen</span>
             </label>
             <label>Übergeordnete Seite
                 <select name="parent_id">
@@ -101,6 +115,7 @@
             <button type="submit">Speichern</button>
         </form>
     </div>
+</div>
 </div>
 </section>
 <?php include __DIR__ . '/../partials/footer.php'; ?>

--- a/public/views/admin/settings.php
+++ b/public/views/admin/settings.php
@@ -1,8 +1,9 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
+<section class="mx-auto w-full max-w-5xl px-4 sm:px-6 lg:px-8">
 <h1>Einstellungen</h1>
 <?php include __DIR__ . '/nav.php'; ?>
 <?php if ($flashSuccess): ?>
-    <div class="alert alert-success"><?= htmlspecialchars($flashSuccess) ?></div>
+    <div class="alert alert-success" role="status" aria-live="polite"><?= htmlspecialchars($flashSuccess) ?></div>
 <?php endif; ?>
 <div class="card">
     <form method="post">
@@ -13,13 +14,13 @@
             <input type="text" name="site_tagline" value="<?= htmlspecialchars($settings['site_tagline'] ?? '') ?>">
         </label>
         <label>Hero-Einleitung
-            <textarea name="hero_intro"><?= htmlspecialchars($settings['hero_intro'] ?? '') ?></textarea>
+            <textarea name="hero_intro" class="rich-text"><?= htmlspecialchars($settings['hero_intro'] ?? '') ?></textarea>
         </label>
         <label>Abgabe Intro
-            <textarea name="adoption_intro"><?= htmlspecialchars($settings['adoption_intro'] ?? '') ?></textarea>
+            <textarea name="adoption_intro" class="rich-text"><?= htmlspecialchars($settings['adoption_intro'] ?? '') ?></textarea>
         </label>
         <label>Footer Text
-            <textarea name="footer_text"><?= htmlspecialchars($settings['footer_text'] ?? '') ?></textarea>
+            <textarea name="footer_text" class="rich-text"><?= htmlspecialchars($settings['footer_text'] ?? '') ?></textarea>
         </label>
         <label>Kontakt E-Mail
             <input type="email" name="contact_email" value="<?= htmlspecialchars($settings['contact_email'] ?? '') ?>">
@@ -27,4 +28,5 @@
         <button type="submit">Speichern</button>
     </form>
 </div>
+</section>
 <?php include __DIR__ . '/../partials/footer.php'; ?>

--- a/public/views/admin/settings.php
+++ b/public/views/admin/settings.php
@@ -1,7 +1,17 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
-<section class="mx-auto w-full max-w-5xl px-4 sm:px-6 lg:px-8">
-<h1>Einstellungen</h1>
+<section class="admin-shell">
+<header class="admin-page-header">
+    <div>
+        <h1 class="admin-title">Einstellungen</h1>
+        <p class="admin-subtitle">Forme die digitale Umgebung – von Terrarium-Branding bis Kontakt – mit wenigen, fokussierten Eingaben.</p>
+    </div>
+    <div class="admin-meta">
+        <span class="badge">Systemkern</span>
+        <span>Individuelle Konfiguration</span>
+    </div>
+</header>
 <?php include __DIR__ . '/nav.php'; ?>
+<div class="admin-section">
 <?php if ($flashSuccess): ?>
     <div class="alert alert-success" role="status" aria-live="polite"><?= htmlspecialchars($flashSuccess) ?></div>
 <?php endif; ?>
@@ -27,6 +37,7 @@
         </label>
         <button type="submit">Speichern</button>
     </form>
+</div>
 </div>
 </section>
 <?php include __DIR__ . '/../partials/footer.php'; ?>

--- a/public/views/admin/users.php
+++ b/public/views/admin/users.php
@@ -1,8 +1,9 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
+<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
 <h1>Benutzerverwaltung</h1>
 <?php include __DIR__ . '/nav.php'; ?>
 <?php if ($flashSuccess): ?>
-    <div class="alert alert-success"><?= htmlspecialchars($flashSuccess) ?></div>
+    <div class="alert alert-success" role="status" aria-live="polite"><?= htmlspecialchars($flashSuccess) ?></div>
 <?php endif; ?>
 <div class="grid" style="grid-template-columns:2fr 1fr;gap:2rem;align-items:start;">
     <div class="card">
@@ -61,4 +62,5 @@
         </form>
     </div>
 </div>
+</section>
 <?php include __DIR__ . '/../partials/footer.php'; ?>

--- a/public/views/admin/users.php
+++ b/public/views/admin/users.php
@@ -1,13 +1,24 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
-<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
-<h1>Benutzerverwaltung</h1>
+<section class="admin-shell">
+<header class="admin-page-header">
+    <div>
+        <h1 class="admin-title">Benutzerverwaltung</h1>
+        <p class="admin-subtitle">Stelle dein Terrarium-Team zusammen und verteile Zugänge mit wenigen warmen Klicks.</p>
+    </div>
+    <div class="admin-meta">
+        <span class="badge">Teamstruktur</span>
+        <span><?= count($users) ?> Mitglieder</span>
+    </div>
+</header>
 <?php include __DIR__ . '/nav.php'; ?>
+<div class="admin-section">
 <?php if ($flashSuccess): ?>
     <div class="alert alert-success" role="status" aria-live="polite"><?= htmlspecialchars($flashSuccess) ?></div>
 <?php endif; ?>
-<div class="grid" style="grid-template-columns:2fr 1fr;gap:2rem;align-items:start;">
+<div class="admin-layout">
     <div class="card">
-        <table class="table">
+        <div class="table-responsive">
+            <table class="table">
             <thead>
                 <tr>
                     <th>Benutzername</th>
@@ -35,7 +46,8 @@
                     </tr>
                 <?php endforeach; ?>
             </tbody>
-        </table>
+            </table>
+        </div>
     </div>
     <div class="card">
         <h2><?= $editUser ? 'Benutzer bearbeiten' : 'Benutzer anlegen' ?></h2>
@@ -55,12 +67,22 @@
                     <option value="staff" <?= (($editUser['role'] ?? '') === 'staff') ? 'selected' : '' ?>>Staff</option>
                 </select>
             </label>
-            <label><input type="checkbox" name="can_manage_animals" value="1" <?= !empty($editUser['can_manage_animals']) ? 'checked' : '' ?>> Tiere verwalten</label>
-            <label><input type="checkbox" name="can_manage_settings" value="1" <?= !empty($editUser['can_manage_settings']) ? 'checked' : '' ?>> Einstellungen bearbeiten</label>
-            <label><input type="checkbox" name="can_manage_adoptions" value="1" <?= !empty($editUser['can_manage_adoptions']) ? 'checked' : '' ?>> Adoption verwalten</label>
+            <label class="form-switch">
+                <input type="checkbox" name="can_manage_animals" value="1" <?= !empty($editUser['can_manage_animals']) ? 'checked' : '' ?>>
+                <span>Tiere verwalten</span>
+            </label>
+            <label class="form-switch">
+                <input type="checkbox" name="can_manage_settings" value="1" <?= !empty($editUser['can_manage_settings']) ? 'checked' : '' ?>>
+                <span>Einstellungen bearbeiten</span>
+            </label>
+            <label class="form-switch">
+                <input type="checkbox" name="can_manage_adoptions" value="1" <?= !empty($editUser['can_manage_adoptions']) ? 'checked' : '' ?>>
+                <span>Adoption verwalten</span>
+            </label>
             <button type="submit">Speichern</button>
         </form>
     </div>
+</div>
 </div>
 </section>
 <?php include __DIR__ . '/../partials/footer.php'; ?>

--- a/public/views/adoption/index.php
+++ b/public/views/adoption/index.php
@@ -1,69 +1,62 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
-<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
-    <header class="max-w-3xl">
-        <h1 class="text-3xl font-semibold text-white sm:text-4xl">Tierabgabe</h1>
-        <p class="mt-2 text-sm text-slate-300">Vermittlungstiere mit Kontaktformular für eine direkte Anfrage.</p>
-    </header>
-    <div class="rich-text-content prose prose-invert mt-6 max-w-none text-slate-200">
-        <?= render_rich_text($settings['adoption_intro'] ?? '') ?>
-    </div>
-    <?php if ($flashSuccess): ?>
-        <div class="mt-6 rounded-2xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-200" role="status" aria-live="polite">
-            <?= htmlspecialchars($flashSuccess) ?>
-        </div>
-    <?php endif; ?>
-    <?php if ($flashError): ?>
-        <div class="mt-6 rounded-2xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-200" role="alert" aria-live="assertive">
-            <?= htmlspecialchars($flashError) ?>
-        </div>
-    <?php endif; ?>
-    <?php $inputClasses = 'mt-1 block w-full rounded-xl border border-white/10 bg-night-900/60 px-3 py-2 text-slate-100 shadow-inner shadow-black/40 focus:border-brand-400 focus:outline-none focus:ring focus:ring-brand-500/40'; ?>
-    <div class="mt-10 grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
-        <?php foreach ($listings as $listing): ?>
-            <article class="flex h-full flex-col rounded-3xl border border-white/5 bg-night-900/70 p-6 shadow-lg shadow-black/30 transition hover:border-brand-400/60 hover:shadow-glow">
-                <?php if (!empty($listing['image_path'])): ?>
-                    <img src="<?= BASE_URL . '/' . htmlspecialchars($listing['image_path']) ?>" alt="<?= htmlspecialchars($listing['title']) ?>" class="mb-4 h-48 w-full rounded-2xl object-cover" loading="lazy">
-                <?php endif; ?>
-                <h3 class="text-xl font-semibold text-white"><?= htmlspecialchars($listing['title']) ?></h3>
-                <?php if (!empty($listing['species'])): ?>
-                    <p class="text-sm text-slate-300"><?= htmlspecialchars($listing['species']) ?></p>
-                <?php endif; ?>
-                <?php if (!empty($listing['genetics'])): ?>
-                    <p class="mt-2 rounded-xl border border-brand-400/40 bg-brand-500/10 px-3 py-2 text-sm text-brand-100">
-                        <span class="font-semibold uppercase tracking-wide">Genetik:</span>
-                        <?= htmlspecialchars($listing['genetics']) ?>
-                    </p>
-                <?php endif; ?>
-                <?php if (!empty($listing['price'])): ?>
-                    <p class="mt-2 text-sm text-slate-200"><strong>Preis:</strong> <?= htmlspecialchars($listing['price']) ?></p>
-                <?php endif; ?>
-                <?php if (!empty($listing['description'])): ?>
-                    <div class="rich-text-content prose prose-invert mt-3 max-w-none text-sm text-slate-200">
-                        <?= render_rich_text($listing['description']) ?>
+<section class="section">
+    <div class="section__inner">
+        <header class="section-header">
+            <h1 class="section-header__title">Tierabgabe &amp; Vermittlung</h1>
+            <p class="section-header__description">Alle aktuellen Vermittlungsinserate mit Morph, Geschlecht, Preis und Kontaktmöglichkeit.</p>
+        </header>
+        <?php if (!empty($settings['adoption_intro'])): ?>
+            <div class="rich-text-content">
+                <?= render_rich_text($settings['adoption_intro']) ?>
+            </div>
+        <?php endif; ?>
+        <div class="listing-grid">
+            <?php foreach ($listings as $listing): ?>
+                <article class="listing-card" id="listing-<?= (int)$listing['id'] ?>">
+                    <?php if (!empty($listing['image_path'])): ?>
+                        <div class="card__media">
+                            <?= render_responsive_picture($listing['image_path'], $listing['title'], [
+                                'sizes' => '(max-width: 768px) 100vw, 420px',
+                            ]) ?>
+                        </div>
+                    <?php endif; ?>
+                    <h2 class="card__title"><?= htmlspecialchars($listing['title']) ?></h2>
+                    <?php if ($badge = render_sex_badge($listing['sex'] ?? null, ['class' => 'badge-gender--inline'])): ?>
+                        <?= $badge ?>
+                    <?php endif; ?>
+                    <div class="listing-card__meta">
+                        <?php if (!empty($listing['species'])): ?>
+                            <span>Art: <?= htmlspecialchars($listing['species']) ?></span>
+                        <?php endif; ?>
+                        <?php if (!empty($listing['morph'])): ?>
+                            <span>Morph: <?= htmlspecialchars($listing['morph']) ?></span>
+                        <?php endif; ?>
+                        <?php if (!empty($listing['genetics'])): ?>
+                            <span>Genetik: <?= htmlspecialchars($listing['genetics']) ?></span>
+                        <?php endif; ?>
+                        <?php if (!empty($listing['birth_year'])): ?>
+                            <span>Geburtsjahr: <?= htmlspecialchars($listing['birth_year']) ?></span>
+                        <?php endif; ?>
+                        <?php if (!empty($listing['price'])): ?>
+                            <span>Preis: <?= htmlspecialchars($listing['price']) ?></span>
+                        <?php endif; ?>
+                        <?php if (!empty($listing['location'])): ?>
+                            <span>Standort: <?= htmlspecialchars($listing['location']) ?></span>
+                        <?php endif; ?>
                     </div>
-                <?php endif; ?>
-                <form method="post" class="mt-6 grid gap-4 rounded-2xl border border-brand-400/30 bg-brand-500/5 p-4 text-sm text-slate-100 shadow-inner shadow-brand-600/10">
-                    <input type="hidden" name="listing_id" value="<?= (int)$listing['id'] ?>">
-                    <label class="space-y-1">
-                        <span class="font-medium text-slate-200">Interessiert an</span>
-                        <input type="text" name="interested_in" value="<?= htmlspecialchars($listing['title']) ?>" class="<?= $inputClasses ?>">
-                    </label>
-                    <label class="space-y-1">
-                        <span class="font-medium text-slate-200">Name</span>
-                        <input type="text" name="name" required class="<?= $inputClasses ?>">
-                    </label>
-                    <label class="space-y-1">
-                        <span class="font-medium text-slate-200">E-Mail</span>
-                        <input type="email" name="email" required class="<?= $inputClasses ?>">
-                    </label>
-                    <label class="space-y-1">
-                        <span class="font-medium text-slate-200">Nachricht</span>
-                        <textarea name="message" required placeholder="Beschreiben Sie Ihre Haltung, Erfahrung und konkreten Fragen." class="<?= $inputClasses ?> h-28"></textarea>
-                    </label>
-                    <button type="submit" class="inline-flex items-center justify-center rounded-full border border-brand-400/60 bg-brand-500/20 px-4 py-2 text-sm font-semibold text-brand-100 transition hover:border-brand-300 hover:bg-brand-500/30">Anfrage senden</button>
-                </form>
-            </article>
-        <?php endforeach; ?>
+                    <?php if (!empty($listing['description'])): ?>
+                        <div class="rich-text-content">
+                            <?= render_rich_text($listing['description']) ?>
+                        </div>
+                    <?php endif; ?>
+                    <?php if (!empty($settings['contact_email'])): ?>
+                        <div class="listing-card__cta">
+                            <a class="button button--outline" href="mailto:<?= htmlspecialchars($settings['contact_email']) ?>?subject=Anfrage%20<?= urlencode($listing['title']) ?>">Direkt anfragen</a>
+                        </div>
+                    <?php endif; ?>
+                </article>
+            <?php endforeach; ?>
+        </div>
     </div>
 </section>
 <?php include __DIR__ . '/../partials/footer.php'; ?>

--- a/public/views/adoption/index.php
+++ b/public/views/adoption/index.php
@@ -1,49 +1,69 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
-<h1>Tierabgabe</h1>
-<p><?= nl2br(htmlspecialchars($settings['adoption_intro'] ?? '')) ?></p>
-<?php if ($flashSuccess): ?>
-    <div class="alert alert-success"><?= htmlspecialchars($flashSuccess) ?></div>
-<?php endif; ?>
-<?php if ($flashError): ?>
-    <div class="alert alert-error"><?= htmlspecialchars($flashError) ?></div>
-<?php endif; ?>
-<div class="grid cards" style="margin-top:2rem;">
-    <?php foreach ($listings as $listing): ?>
-        <article class="card">
-            <?php if (!empty($listing['image_path'])): ?>
-                <img src="<?= BASE_URL . '/' . htmlspecialchars($listing['image_path']) ?>" alt="<?= htmlspecialchars($listing['title']) ?>">
-            <?php endif; ?>
-            <h3><?= htmlspecialchars($listing['title']) ?></h3>
-            <?php if (!empty($listing['species'])): ?>
-                <p><?= htmlspecialchars($listing['species']) ?></p>
-            <?php endif; ?>
-            <?php if (!empty($listing['genetics'])): ?>
-                <span class="badge">Genetik</span>
-                <p><?= htmlspecialchars($listing['genetics']) ?></p>
-            <?php endif; ?>
-            <?php if (!empty($listing['price'])): ?>
-                <p><strong>Preis:</strong> <?= htmlspecialchars($listing['price']) ?></p>
-            <?php endif; ?>
-            <?php if (!empty($listing['description'])): ?>
-                <p><?= nl2br(htmlspecialchars($listing['description'])) ?></p>
-            <?php endif; ?>
-            <form method="post" class="card" style="background:rgba(148,163,184,0.08);margin-top:1rem;">
-                <input type="hidden" name="listing_id" value="<?= (int)$listing['id'] ?>">
-                <label>Interessiert an
-                    <input type="text" name="interested_in" value="<?= htmlspecialchars($listing['title']) ?>">
-                </label>
-                <label>Name
-                    <input type="text" name="name" required>
-                </label>
-                <label>E-Mail
-                    <input type="email" name="email" required>
-                </label>
-                <label>Nachricht
-                    <textarea name="message" required placeholder="Beschreibe deine Haltung, Erfahrung und Fragen."></textarea>
-                </label>
-                <button type="submit">Anfrage senden</button>
-            </form>
-        </article>
-    <?php endforeach; ?>
-</div>
+<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
+    <header class="max-w-3xl">
+        <h1 class="text-3xl font-semibold text-white sm:text-4xl">Tierabgabe</h1>
+        <p class="mt-2 text-sm text-slate-300">Vermittlungstiere mit Kontaktformular für eine direkte Anfrage.</p>
+    </header>
+    <div class="rich-text-content prose prose-invert mt-6 max-w-none text-slate-200">
+        <?= render_rich_text($settings['adoption_intro'] ?? '') ?>
+    </div>
+    <?php if ($flashSuccess): ?>
+        <div class="mt-6 rounded-2xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-200" role="status" aria-live="polite">
+            <?= htmlspecialchars($flashSuccess) ?>
+        </div>
+    <?php endif; ?>
+    <?php if ($flashError): ?>
+        <div class="mt-6 rounded-2xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-200" role="alert" aria-live="assertive">
+            <?= htmlspecialchars($flashError) ?>
+        </div>
+    <?php endif; ?>
+    <?php $inputClasses = 'mt-1 block w-full rounded-xl border border-white/10 bg-night-900/60 px-3 py-2 text-slate-100 shadow-inner shadow-black/40 focus:border-brand-400 focus:outline-none focus:ring focus:ring-brand-500/40'; ?>
+    <div class="mt-10 grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
+        <?php foreach ($listings as $listing): ?>
+            <article class="flex h-full flex-col rounded-3xl border border-white/5 bg-night-900/70 p-6 shadow-lg shadow-black/30 transition hover:border-brand-400/60 hover:shadow-glow">
+                <?php if (!empty($listing['image_path'])): ?>
+                    <img src="<?= BASE_URL . '/' . htmlspecialchars($listing['image_path']) ?>" alt="<?= htmlspecialchars($listing['title']) ?>" class="mb-4 h-48 w-full rounded-2xl object-cover" loading="lazy">
+                <?php endif; ?>
+                <h3 class="text-xl font-semibold text-white"><?= htmlspecialchars($listing['title']) ?></h3>
+                <?php if (!empty($listing['species'])): ?>
+                    <p class="text-sm text-slate-300"><?= htmlspecialchars($listing['species']) ?></p>
+                <?php endif; ?>
+                <?php if (!empty($listing['genetics'])): ?>
+                    <p class="mt-2 rounded-xl border border-brand-400/40 bg-brand-500/10 px-3 py-2 text-sm text-brand-100">
+                        <span class="font-semibold uppercase tracking-wide">Genetik:</span>
+                        <?= htmlspecialchars($listing['genetics']) ?>
+                    </p>
+                <?php endif; ?>
+                <?php if (!empty($listing['price'])): ?>
+                    <p class="mt-2 text-sm text-slate-200"><strong>Preis:</strong> <?= htmlspecialchars($listing['price']) ?></p>
+                <?php endif; ?>
+                <?php if (!empty($listing['description'])): ?>
+                    <div class="rich-text-content prose prose-invert mt-3 max-w-none text-sm text-slate-200">
+                        <?= render_rich_text($listing['description']) ?>
+                    </div>
+                <?php endif; ?>
+                <form method="post" class="mt-6 grid gap-4 rounded-2xl border border-brand-400/30 bg-brand-500/5 p-4 text-sm text-slate-100 shadow-inner shadow-brand-600/10">
+                    <input type="hidden" name="listing_id" value="<?= (int)$listing['id'] ?>">
+                    <label class="space-y-1">
+                        <span class="font-medium text-slate-200">Interessiert an</span>
+                        <input type="text" name="interested_in" value="<?= htmlspecialchars($listing['title']) ?>" class="<?= $inputClasses ?>">
+                    </label>
+                    <label class="space-y-1">
+                        <span class="font-medium text-slate-200">Name</span>
+                        <input type="text" name="name" required class="<?= $inputClasses ?>">
+                    </label>
+                    <label class="space-y-1">
+                        <span class="font-medium text-slate-200">E-Mail</span>
+                        <input type="email" name="email" required class="<?= $inputClasses ?>">
+                    </label>
+                    <label class="space-y-1">
+                        <span class="font-medium text-slate-200">Nachricht</span>
+                        <textarea name="message" required placeholder="Beschreiben Sie Ihre Haltung, Erfahrung und konkreten Fragen." class="<?= $inputClasses ?> h-28"></textarea>
+                    </label>
+                    <button type="submit" class="inline-flex items-center justify-center rounded-full border border-brand-400/60 bg-brand-500/20 px-4 py-2 text-sm font-semibold text-brand-100 transition hover:border-brand-300 hover:bg-brand-500/30">Anfrage senden</button>
+                </form>
+            </article>
+        <?php endforeach; ?>
+    </div>
+</section>
 <?php include __DIR__ . '/../partials/footer.php'; ?>

--- a/public/views/animals/index.php
+++ b/public/views/animals/index.php
@@ -1,41 +1,49 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
-<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
-    <header class="max-w-3xl">
-        <h1 class="text-3xl font-semibold text-white sm:text-4xl">Tierübersicht</h1>
-        <p class="mt-2 text-sm text-slate-300">Alle öffentlich sichtbaren Tiere aus unserem Bestand auf einen Blick.</p>
-    </header>
-    <div class="mt-10 grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
-        <?php foreach ($animals as $animal): ?>
-            <article class="flex h-full flex-col rounded-3xl border border-white/5 bg-night-900/70 p-6 shadow-lg shadow-black/30 transition hover:border-brand-400/60 hover:shadow-glow">
-                <?php if (!empty($animal['image_path'])): ?>
-                    <img src="<?= BASE_URL . '/' . htmlspecialchars($animal['image_path']) ?>" alt="<?= htmlspecialchars($animal['name']) ?>" class="mb-4 h-48 w-full rounded-2xl object-cover" loading="lazy">
-                <?php endif; ?>
-                <h3 class="text-xl font-semibold text-white">
-                    <?= htmlspecialchars($animal['name']) ?>
-                    <?php if (!empty($animal['is_piebald'])): ?>
-                        <span class="ml-2 inline-flex items-center justify-center rounded-full border border-brand-400 bg-brand-500/20 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-brand-100" title="Geschecktes Tier" aria-label="Geschecktes Tier">Gescheckt</span>
+<section class="section">
+    <div class="section__inner">
+        <header class="section-header">
+            <h1 class="section-header__title">Tierübersicht</h1>
+            <p class="section-header__description">Alle öffentlich sichtbaren Tiere aus unserem Bestand – inklusive Morph, Geschlecht, Herkunft und Gesundheitsstatus.</p>
+        </header>
+        <div class="card-grid">
+            <?php foreach ($animals as $animal): ?>
+                <article id="animal-<?= (int)$animal['id'] ?>" class="card card--highlight">
+                    <?php if (!empty($animal['image_path'])): ?>
+                        <div class="card__media">
+                            <?= render_responsive_picture($animal['image_path'], $animal['name'] . ' – ' . $animal['species'], [
+                                'sizes' => '(max-width: 768px) 100vw, 420px',
+                            ]) ?>
+                        </div>
                     <?php endif; ?>
-                </h3>
-                <p class="text-sm text-slate-300"><?= htmlspecialchars($animal['species']) ?></p>
-                <?php if (!empty($animal['age'])): ?>
-                    <p class="mt-2 text-sm text-slate-200"><strong>Alter:</strong> <?= htmlspecialchars($animal['age']) ?></p>
-                <?php endif; ?>
-                <?php if (!empty($animal['genetics'])): ?>
-                    <p class="mt-2 rounded-xl border border-brand-400/40 bg-brand-500/10 px-3 py-2 text-sm text-brand-100">
-                        <span class="font-semibold uppercase tracking-wide">Genetik:</span>
-                        <?= htmlspecialchars($animal['genetics']) ?>
-                    </p>
-                <?php endif; ?>
-                <?php if (!empty($animal['origin'])): ?>
-                    <p class="mt-2 text-sm text-slate-200"><strong>Herkunft:</strong> <?= htmlspecialchars($animal['origin']) ?></p>
-                <?php endif; ?>
-                <?php if (!empty($animal['description'])): ?>
-                    <div class="rich-text-content prose prose-invert mt-3 max-w-none text-sm text-slate-200">
-                        <?= render_rich_text($animal['description']) ?>
+                    <h2 class="card__title">
+                        <?= htmlspecialchars($animal['name']) ?>
+                        <?php if (!empty($animal['is_piebald'])): ?>
+                            <span class="badge" title="Geschecktes Tier" aria-label="Geschecktes Tier">Gescheckt</span>
+                        <?php endif; ?>
+                    </h2>
+                    <p class="card__subtitle"><?= htmlspecialchars($animal['species']) ?></p>
+                    <?php if ($badge = render_sex_badge($animal['sex'] ?? null, ['class' => 'badge-gender--inline'])): ?>
+                        <?= $badge ?>
+                    <?php endif; ?>
+                    <div class="card__meta">
+                        <?php if (!empty($animal['age'])): ?>
+                            <span>Alter: <?= htmlspecialchars($animal['age']) ?></span>
+                        <?php endif; ?>
+                        <?php if (!empty($animal['genetics'])): ?>
+                            <span>Genetik: <?= htmlspecialchars($animal['genetics']) ?></span>
+                        <?php endif; ?>
+                        <?php if (!empty($animal['origin'])): ?>
+                            <span>Herkunft: <?= htmlspecialchars($animal['origin']) ?></span>
+                        <?php endif; ?>
                     </div>
-                <?php endif; ?>
-            </article>
-        <?php endforeach; ?>
+                    <?php if (!empty($animal['description'])): ?>
+                        <div class="rich-text-content">
+                            <?= render_rich_text($animal['description']) ?>
+                        </div>
+                    <?php endif; ?>
+                </article>
+            <?php endforeach; ?>
+        </div>
     </div>
 </section>
 <?php include __DIR__ . '/../partials/footer.php'; ?>

--- a/public/views/animals/index.php
+++ b/public/views/animals/index.php
@@ -1,28 +1,41 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
-<h1>Tierübersicht</h1>
-<p class="text-muted">Alle öffentlich sichtbaren Tiere aus unserem Bestand.</p>
-<div class="grid cards" style="margin-top:2rem;">
-    <?php foreach ($animals as $animal): ?>
-        <article class="card">
-            <?php if (!empty($animal['image_path'])): ?>
-                <img src="<?= BASE_URL . '/' . htmlspecialchars($animal['image_path']) ?>" alt="<?= htmlspecialchars($animal['name']) ?>">
-            <?php endif; ?>
-            <h3><?= htmlspecialchars($animal['name']) ?></h3>
-            <p><?= htmlspecialchars($animal['species']) ?></p>
-            <?php if (!empty($animal['age'])): ?>
-                <p><strong>Alter:</strong> <?= htmlspecialchars($animal['age']) ?></p>
-            <?php endif; ?>
-            <?php if (!empty($animal['genetics'])): ?>
-                <span class="badge">Genetik</span>
-                <p><?= htmlspecialchars($animal['genetics']) ?></p>
-            <?php endif; ?>
-            <?php if (!empty($animal['origin'])): ?>
-                <p><strong>Herkunft:</strong> <?= htmlspecialchars($animal['origin']) ?></p>
-            <?php endif; ?>
-            <?php if (!empty($animal['description'])): ?>
-                <p><?= nl2br(htmlspecialchars($animal['description'])) ?></p>
-            <?php endif; ?>
-        </article>
-    <?php endforeach; ?>
-</div>
+<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
+    <header class="max-w-3xl">
+        <h1 class="text-3xl font-semibold text-white sm:text-4xl">Tierübersicht</h1>
+        <p class="mt-2 text-sm text-slate-300">Alle öffentlich sichtbaren Tiere aus unserem Bestand auf einen Blick.</p>
+    </header>
+    <div class="mt-10 grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
+        <?php foreach ($animals as $animal): ?>
+            <article class="flex h-full flex-col rounded-3xl border border-white/5 bg-night-900/70 p-6 shadow-lg shadow-black/30 transition hover:border-brand-400/60 hover:shadow-glow">
+                <?php if (!empty($animal['image_path'])): ?>
+                    <img src="<?= BASE_URL . '/' . htmlspecialchars($animal['image_path']) ?>" alt="<?= htmlspecialchars($animal['name']) ?>" class="mb-4 h-48 w-full rounded-2xl object-cover" loading="lazy">
+                <?php endif; ?>
+                <h3 class="text-xl font-semibold text-white">
+                    <?= htmlspecialchars($animal['name']) ?>
+                    <?php if (!empty($animal['is_piebald'])): ?>
+                        <span class="ml-2 inline-flex items-center justify-center rounded-full border border-brand-400 bg-brand-500/20 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-brand-100" title="Geschecktes Tier" aria-label="Geschecktes Tier">Gescheckt</span>
+                    <?php endif; ?>
+                </h3>
+                <p class="text-sm text-slate-300"><?= htmlspecialchars($animal['species']) ?></p>
+                <?php if (!empty($animal['age'])): ?>
+                    <p class="mt-2 text-sm text-slate-200"><strong>Alter:</strong> <?= htmlspecialchars($animal['age']) ?></p>
+                <?php endif; ?>
+                <?php if (!empty($animal['genetics'])): ?>
+                    <p class="mt-2 rounded-xl border border-brand-400/40 bg-brand-500/10 px-3 py-2 text-sm text-brand-100">
+                        <span class="font-semibold uppercase tracking-wide">Genetik:</span>
+                        <?= htmlspecialchars($animal['genetics']) ?>
+                    </p>
+                <?php endif; ?>
+                <?php if (!empty($animal['origin'])): ?>
+                    <p class="mt-2 text-sm text-slate-200"><strong>Herkunft:</strong> <?= htmlspecialchars($animal['origin']) ?></p>
+                <?php endif; ?>
+                <?php if (!empty($animal['description'])): ?>
+                    <div class="rich-text-content prose prose-invert mt-3 max-w-none text-sm text-slate-200">
+                        <?= render_rich_text($animal['description']) ?>
+                    </div>
+                <?php endif; ?>
+            </article>
+        <?php endforeach; ?>
+    </div>
+</section>
 <?php include __DIR__ . '/../partials/footer.php'; ?>

--- a/public/views/animals/my_animals.php
+++ b/public/views/animals/my_animals.php
@@ -1,32 +1,47 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
-<h1>Meine Tiere</h1>
-<p class="text-muted">Nur du kannst diese Tiere sehen. Bearbeitungen erfolgen im Adminbereich.</p>
-<?php if (empty($animals)): ?>
-    <div class="card">Noch keine Tiere zugewiesen.</div>
-<?php else: ?>
-    <div class="grid cards" style="margin-top:2rem;">
-        <?php foreach ($animals as $animal): ?>
-            <article class="card">
-                <?php if (!empty($animal['image_path'])): ?>
-                    <img src="<?= BASE_URL . '/' . htmlspecialchars($animal['image_path']) ?>" alt="<?= htmlspecialchars($animal['name']) ?>">
-                <?php endif; ?>
-                <h3><?= htmlspecialchars($animal['name']) ?></h3>
-                <p><?= htmlspecialchars($animal['species']) ?></p>
-                <?php if (!empty($animal['age'])): ?>
-                    <p><strong>Alter:</strong> <?= htmlspecialchars($animal['age']) ?></p>
-                <?php endif; ?>
-                <?php if (!empty($animal['genetics'])): ?>
-                    <span class="badge">Genetik</span>
-                    <p><?= htmlspecialchars($animal['genetics']) ?></p>
-                <?php endif; ?>
-                <?php if (!empty($animal['origin'])): ?>
-                    <p><strong>Herkunft:</strong> <?= htmlspecialchars($animal['origin']) ?></p>
-                <?php endif; ?>
-                <?php if (!empty($animal['special_notes'])): ?>
-                    <p><?= nl2br(htmlspecialchars($animal['special_notes'])) ?></p>
-                <?php endif; ?>
-            </article>
-        <?php endforeach; ?>
-    </div>
-<?php endif; ?>
+<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
+    <header class="max-w-3xl">
+        <h1 class="text-3xl font-semibold text-white sm:text-4xl">Meine Tiere</h1>
+        <p class="mt-2 text-sm text-slate-300">Nur du kannst diese Tiere sehen. Bearbeitungen erfolgen im Adminbereich.</p>
+    </header>
+    <?php if (empty($animals)): ?>
+        <div class="mt-8 rounded-3xl border border-white/5 bg-night-900/70 p-8 text-center text-sm text-slate-300">
+            Es wurden bislang keine Tiere zugewiesen.
+        </div>
+    <?php else: ?>
+        <div class="mt-10 grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
+            <?php foreach ($animals as $animal): ?>
+                <article class="flex h-full flex-col rounded-3xl border border-white/5 bg-night-900/70 p-6 shadow-lg shadow-black/30 transition hover:border-brand-400/60 hover:shadow-glow">
+                    <?php if (!empty($animal['image_path'])): ?>
+                        <img src="<?= BASE_URL . '/' . htmlspecialchars($animal['image_path']) ?>" alt="<?= htmlspecialchars($animal['name']) ?>" class="mb-4 h-48 w-full rounded-2xl object-cover" loading="lazy">
+                    <?php endif; ?>
+                    <h3 class="text-xl font-semibold text-white">
+                        <?= htmlspecialchars($animal['name']) ?>
+                        <?php if (!empty($animal['is_piebald'])): ?>
+                            <span class="ml-2 inline-flex items-center justify-center rounded-full border border-brand-400 bg-brand-500/20 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-brand-100" title="Geschecktes Tier" aria-label="Geschecktes Tier">Gescheckt</span>
+                        <?php endif; ?>
+                    </h3>
+                    <p class="text-sm text-slate-300"><?= htmlspecialchars($animal['species']) ?></p>
+                    <?php if (!empty($animal['age'])): ?>
+                        <p class="mt-2 text-sm text-slate-200"><strong>Alter:</strong> <?= htmlspecialchars($animal['age']) ?></p>
+                    <?php endif; ?>
+                    <?php if (!empty($animal['genetics'])): ?>
+                        <p class="mt-2 rounded-xl border border-brand-400/40 bg-brand-500/10 px-3 py-2 text-sm text-brand-100">
+                            <span class="font-semibold uppercase tracking-wide">Genetik:</span>
+                            <?= htmlspecialchars($animal['genetics']) ?>
+                        </p>
+                    <?php endif; ?>
+                    <?php if (!empty($animal['origin'])): ?>
+                        <p class="mt-2 text-sm text-slate-200"><strong>Herkunft:</strong> <?= htmlspecialchars($animal['origin']) ?></p>
+                    <?php endif; ?>
+                    <?php if (!empty($animal['special_notes'])): ?>
+                        <div class="rich-text-content prose prose-invert mt-3 max-w-none text-sm text-slate-200">
+                            <?= render_rich_text($animal['special_notes']) ?>
+                        </div>
+                    <?php endif; ?>
+                </article>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+</section>
 <?php include __DIR__ . '/../partials/footer.php'; ?>

--- a/public/views/animals/my_animals.php
+++ b/public/views/animals/my_animals.php
@@ -1,47 +1,56 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
-<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
-    <header class="max-w-3xl">
-        <h1 class="text-3xl font-semibold text-white sm:text-4xl">Meine Tiere</h1>
-        <p class="mt-2 text-sm text-slate-300">Nur du kannst diese Tiere sehen. Bearbeitungen erfolgen im Adminbereich.</p>
-    </header>
-    <?php if (empty($animals)): ?>
-        <div class="mt-8 rounded-3xl border border-white/5 bg-night-900/70 p-8 text-center text-sm text-slate-300">
-            Es wurden bislang keine Tiere zugewiesen.
-        </div>
-    <?php else: ?>
-        <div class="mt-10 grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
-            <?php foreach ($animals as $animal): ?>
-                <article class="flex h-full flex-col rounded-3xl border border-white/5 bg-night-900/70 p-6 shadow-lg shadow-black/30 transition hover:border-brand-400/60 hover:shadow-glow">
-                    <?php if (!empty($animal['image_path'])): ?>
-                        <img src="<?= BASE_URL . '/' . htmlspecialchars($animal['image_path']) ?>" alt="<?= htmlspecialchars($animal['name']) ?>" class="mb-4 h-48 w-full rounded-2xl object-cover" loading="lazy">
-                    <?php endif; ?>
-                    <h3 class="text-xl font-semibold text-white">
-                        <?= htmlspecialchars($animal['name']) ?>
-                        <?php if (!empty($animal['is_piebald'])): ?>
-                            <span class="ml-2 inline-flex items-center justify-center rounded-full border border-brand-400 bg-brand-500/20 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-brand-100" title="Geschecktes Tier" aria-label="Geschecktes Tier">Gescheckt</span>
+<section class="section">
+    <div class="section__inner">
+        <header class="section-header">
+            <h1 class="section-header__title">Meine Tiere</h1>
+            <p class="section-header__description">Nur für dich sichtbar – verwalte Details im Adminbereich und halte Stammdaten aktuell.</p>
+        </header>
+        <?php if (empty($animals)): ?>
+            <div class="highlight-card">
+                <strong>Keine Tiere hinterlegt</strong>
+                <p>Aktuell sind dir keine Tiere zugeordnet. Ergänze Tiere im Adminbereich, um ihren Status zu verfolgen.</p>
+            </div>
+        <?php else: ?>
+            <div class="card-grid">
+                <?php foreach ($animals as $animal): ?>
+                    <article class="card card--neutral" id="animal-<?= (int)$animal['id'] ?>">
+                        <?php if (!empty($animal['image_path'])): ?>
+                            <div class="card__media">
+                                <?= render_responsive_picture($animal['image_path'], $animal['name'], [
+                                    'sizes' => '(max-width: 768px) 100vw, 360px',
+                                ]) ?>
+                            </div>
                         <?php endif; ?>
-                    </h3>
-                    <p class="text-sm text-slate-300"><?= htmlspecialchars($animal['species']) ?></p>
-                    <?php if (!empty($animal['age'])): ?>
-                        <p class="mt-2 text-sm text-slate-200"><strong>Alter:</strong> <?= htmlspecialchars($animal['age']) ?></p>
-                    <?php endif; ?>
-                    <?php if (!empty($animal['genetics'])): ?>
-                        <p class="mt-2 rounded-xl border border-brand-400/40 bg-brand-500/10 px-3 py-2 text-sm text-brand-100">
-                            <span class="font-semibold uppercase tracking-wide">Genetik:</span>
-                            <?= htmlspecialchars($animal['genetics']) ?>
-                        </p>
-                    <?php endif; ?>
-                    <?php if (!empty($animal['origin'])): ?>
-                        <p class="mt-2 text-sm text-slate-200"><strong>Herkunft:</strong> <?= htmlspecialchars($animal['origin']) ?></p>
-                    <?php endif; ?>
-                    <?php if (!empty($animal['special_notes'])): ?>
-                        <div class="rich-text-content prose prose-invert mt-3 max-w-none text-sm text-slate-200">
-                            <?= render_rich_text($animal['special_notes']) ?>
+                        <h2 class="card__title">
+                            <?= htmlspecialchars($animal['name']) ?>
+                            <?php if (!empty($animal['is_piebald'])): ?>
+                                <span class="badge" title="Geschecktes Tier" aria-label="Geschecktes Tier">Gescheckt</span>
+                            <?php endif; ?>
+                        </h2>
+                        <p class="card__subtitle"><?= htmlspecialchars($animal['species']) ?></p>
+                        <?php if ($badge = render_sex_badge($animal['sex'] ?? null, ['class' => 'badge-gender--inline'])): ?>
+                            <?= $badge ?>
+                        <?php endif; ?>
+                        <div class="card__meta">
+                            <?php if (!empty($animal['age'])): ?>
+                                <span>Alter: <?= htmlspecialchars($animal['age']) ?></span>
+                            <?php endif; ?>
+                            <?php if (!empty($animal['genetics'])): ?>
+                                <span>Genetik: <?= htmlspecialchars($animal['genetics']) ?></span>
+                            <?php endif; ?>
+                            <?php if (!empty($animal['origin'])): ?>
+                                <span>Herkunft: <?= htmlspecialchars($animal['origin']) ?></span>
+                            <?php endif; ?>
                         </div>
-                    <?php endif; ?>
-                </article>
-            <?php endforeach; ?>
-        </div>
-    <?php endif; ?>
+                        <?php if (!empty($animal['special_notes'])): ?>
+                            <div class="rich-text-content">
+                                <?= render_rich_text($animal['special_notes']) ?>
+                            </div>
+                        <?php endif; ?>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+        <?php endif; ?>
+    </div>
 </section>
 <?php include __DIR__ . '/../partials/footer.php'; ?>

--- a/public/views/auth/login.php
+++ b/public/views/auth/login.php
@@ -1,19 +1,22 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
-<div class="grid" style="max-width:480px;margin:0 auto;">
-    <div class="card">
-        <h2>Login</h2>
+<section class="mx-auto flex w-full max-w-md flex-col gap-6 px-4 sm:px-6 lg:px-8">
+    <div class="rounded-3xl border border-white/5 bg-night-900/70 p-8 shadow-lg shadow-black/30">
+        <h2 class="text-2xl font-semibold text-white">Login</h2>
         <?php if ($error = flash('error')): ?>
-            <div class="alert alert-error"><?= htmlspecialchars($error) ?></div>
+            <div class="mt-4 rounded-2xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-200" role="alert" aria-live="assertive"><?= htmlspecialchars($error) ?></div>
         <?php endif; ?>
-        <form method="post" action="<?= BASE_URL ?>/index.php?route=login">
-            <label>Benutzername
-                <input type="text" name="username" required autofocus>
+        <?php $inputClasses = 'mt-1 block w-full rounded-xl border border-white/10 bg-night-900/60 px-3 py-2 text-slate-100 shadow-inner shadow-black/40 focus:border-brand-400 focus:outline-none focus:ring focus:ring-brand-500/40'; ?>
+        <form method="post" action="<?= BASE_URL ?>/index.php?route=login" class="mt-6 grid gap-4 text-sm text-slate-200">
+            <label class="space-y-1">
+                <span class="font-medium text-slate-200">Benutzername</span>
+                <input type="text" name="username" required autofocus class="<?= $inputClasses ?>">
             </label>
-            <label>Passwort
-                <input type="password" name="password" required>
+            <label class="space-y-1">
+                <span class="font-medium text-slate-200">Passwort</span>
+                <input type="password" name="password" required class="<?= $inputClasses ?>">
             </label>
-            <button type="submit">Anmelden</button>
+            <button type="submit" class="mt-4 inline-flex items-center justify-center rounded-full border border-brand-400/60 bg-brand-500/20 px-4 py-2 text-sm font-semibold text-brand-100 transition hover:border-brand-300 hover:bg-brand-500/30">Anmelden</button>
         </form>
     </div>
-</div>
+</section>
 <?php include __DIR__ . '/../partials/footer.php'; ?>

--- a/public/views/auth/login.php
+++ b/public/views/auth/login.php
@@ -1,22 +1,23 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
-<section class="mx-auto flex w-full max-w-md flex-col gap-6 px-4 sm:px-6 lg:px-8">
-    <div class="rounded-3xl border border-white/5 bg-night-900/70 p-8 shadow-lg shadow-black/30">
-        <h2 class="text-2xl font-semibold text-white">Login</h2>
-        <?php if ($error = flash('error')): ?>
-            <div class="mt-4 rounded-2xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-200" role="alert" aria-live="assertive"><?= htmlspecialchars($error) ?></div>
-        <?php endif; ?>
-        <?php $inputClasses = 'mt-1 block w-full rounded-xl border border-white/10 bg-night-900/60 px-3 py-2 text-slate-100 shadow-inner shadow-black/40 focus:border-brand-400 focus:outline-none focus:ring focus:ring-brand-500/40'; ?>
-        <form method="post" action="<?= BASE_URL ?>/index.php?route=login" class="mt-6 grid gap-4 text-sm text-slate-200">
-            <label class="space-y-1">
-                <span class="font-medium text-slate-200">Benutzername</span>
-                <input type="text" name="username" required autofocus class="<?= $inputClasses ?>">
-            </label>
-            <label class="space-y-1">
-                <span class="font-medium text-slate-200">Passwort</span>
-                <input type="password" name="password" required class="<?= $inputClasses ?>">
-            </label>
-            <button type="submit" class="mt-4 inline-flex items-center justify-center rounded-full border border-brand-400/60 bg-brand-500/20 px-4 py-2 text-sm font-semibold text-brand-100 transition hover:border-brand-300 hover:bg-brand-500/30">Anmelden</button>
-        </form>
+<section class="section">
+    <div class="section__inner" style="max-width:480px;">
+        <article class="card">
+            <h2 class="card__title">Login</h2>
+            <?php if ($error = flash('error')): ?>
+                <div class="alert alert-error" role="alert" aria-live="assertive"><?= htmlspecialchars($error) ?></div>
+            <?php endif; ?>
+            <form method="post" action="<?= BASE_URL ?>/index.php?route=login" class="form-grid">
+                <label class="label">Benutzername
+                    <input type="text" name="username" required autofocus class="input">
+                </label>
+                <label class="label">Passwort
+                    <input type="password" name="password" required class="input">
+                </label>
+                <div class="form-actions">
+                    <button type="submit" class="button button--primary">Anmelden</button>
+                </div>
+            </form>
+        </article>
     </div>
 </section>
 <?php include __DIR__ . '/../partials/footer.php'; ?>

--- a/public/views/breeding/index.php
+++ b/public/views/breeding/index.php
@@ -1,0 +1,76 @@
+<?php include __DIR__ . '/../partials/header.php'; ?>
+<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
+    <header class="max-w-3xl">
+        <h1 class="text-3xl font-semibold text-white sm:text-4xl">Zuchtplanung</h1>
+        <p class="mt-2 text-sm text-slate-300">Interne Übersicht über geplante Verpaarungen und Inkubationsschritte.</p>
+    </header>
+    <div class="mt-10 grid gap-8">
+        <?php foreach ($breedingPlans as $plan): ?>
+            <article class="rounded-3xl border border-white/5 bg-night-900/70 p-6 shadow-lg shadow-black/30">
+                <header class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                        <h2 class="text-2xl font-semibold text-white"><?= htmlspecialchars($plan['title']) ?></h2>
+                        <p class="text-xs uppercase tracking-wide text-slate-400">Saison: <?= htmlspecialchars($plan['season'] ?: 'offen') ?></p>
+                    </div>
+                </header>
+                <?php if (!empty($plan['expected_genetics'])): ?>
+                    <div class="mt-6 rounded-2xl border border-brand-400/40 bg-brand-500/10 p-4">
+                        <h3 class="text-sm font-semibold uppercase tracking-wide text-brand-100">Erwartete Genetik</h3>
+                        <div class="rich-text-content prose prose-invert mt-3 max-w-none text-sm text-slate-100">
+                            <?= render_rich_text($plan['expected_genetics']) ?>
+                        </div>
+                    </div>
+                <?php endif; ?>
+                <?php if (!empty($plan['incubation_notes'])): ?>
+                    <div class="mt-6 rounded-2xl border border-white/10 bg-white/5 p-4">
+                        <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-200">Inkubationsnotizen</h3>
+                        <div class="rich-text-content prose prose-invert mt-3 max-w-none text-sm text-slate-100">
+                            <?= render_rich_text($plan['incubation_notes']) ?>
+                        </div>
+                    </div>
+                <?php endif; ?>
+                <?php if (!empty($plan['notes'])): ?>
+                    <div class="mt-6 rounded-2xl border border-white/10 bg-white/5 p-4">
+                        <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-200">Notizen</h3>
+                        <div class="rich-text-content prose prose-invert mt-3 max-w-none text-sm text-slate-100">
+                            <?= render_rich_text($plan['notes']) ?>
+                        </div>
+                    </div>
+                <?php endif; ?>
+                <h3 class="mt-8 text-lg font-semibold text-white">Elterntiere</h3>
+                <?php if (empty($plan['parents'])): ?>
+                    <p class="mt-2 text-sm text-slate-400">Noch keine Eltern hinterlegt.</p>
+                <?php else: ?>
+                    <ul class="mt-4 grid gap-4 sm:grid-cols-2">
+                        <?php foreach ($plan['parents'] as $parent): ?>
+                            <li class="rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-slate-200">
+                                <div class="flex items-center justify-between gap-3">
+                                    <strong class="text-base text-white"><?= htmlspecialchars($parent['parent_type'] === 'virtual' ? ($parent['name'] ?: 'Virtuell') : ($parent['animal_name'] ?? $parent['name'] ?? 'Unbenannt')) ?></strong>
+                                    <?php if ($parent['sex']): ?>
+                                        <span class="inline-flex items-center justify-center rounded-full border border-brand-400 bg-brand-500/20 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-brand-100"><?= htmlspecialchars(strtoupper($parent['sex'])) ?></span>
+                                    <?php endif; ?>
+                                </div>
+                                <p class="mt-1 text-xs uppercase tracking-wide text-slate-400">
+                                    <?= htmlspecialchars($parent['parent_type'] === 'virtual' ? 'Virtuelles Tier' : 'Bestandstier') ?>
+                                </p>
+                                <?php if ($parent['parent_type'] === 'animal' && $parent['animal_species']): ?>
+                                    <p class="mt-2 text-sm text-slate-200"><?= htmlspecialchars($parent['animal_species']) ?></p>
+                                <?php elseif (!empty($parent['species'])): ?>
+                                    <p class="mt-2 text-sm text-slate-200"><?= htmlspecialchars($parent['species']) ?></p>
+                                <?php endif; ?>
+                                <?php if (!empty($parent['animal_genetics']) || !empty($parent['genetics'])): ?>
+                                    <p class="mt-2 text-sm text-slate-200"><strong>Genetik:</strong> <?= htmlspecialchars($parent['animal_genetics'] ?? $parent['genetics']) ?></p>
+                                <?php endif; ?>
+                                <?php if (!empty($parent['notes'])): ?>
+                                    <p class="mt-2 whitespace-pre-line text-sm text-slate-200"><?= htmlspecialchars($parent['notes']) ?></p>
+                                <?php endif; ?>
+                            </li>
+                        <?php endforeach; ?>
+                    </ul>
+                <?php endif; ?>
+            </article>
+        <?php endforeach; ?>
+    </div>
+</section>
+<?php include __DIR__ . '/../partials/footer.php'; ?>
+

--- a/public/views/breeding/index.php
+++ b/public/views/breeding/index.php
@@ -1,76 +1,67 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
-<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
-    <header class="max-w-3xl">
-        <h1 class="text-3xl font-semibold text-white sm:text-4xl">Zuchtplanung</h1>
-        <p class="mt-2 text-sm text-slate-300">Interne Übersicht über geplante Verpaarungen und Inkubationsschritte.</p>
-    </header>
-    <div class="mt-10 grid gap-8">
-        <?php foreach ($breedingPlans as $plan): ?>
-            <article class="rounded-3xl border border-white/5 bg-night-900/70 p-6 shadow-lg shadow-black/30">
-                <header class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                    <div>
-                        <h2 class="text-2xl font-semibold text-white"><?= htmlspecialchars($plan['title']) ?></h2>
-                        <p class="text-xs uppercase tracking-wide text-slate-400">Saison: <?= htmlspecialchars($plan['season'] ?: 'offen') ?></p>
-                    </div>
-                </header>
-                <?php if (!empty($plan['expected_genetics'])): ?>
-                    <div class="mt-6 rounded-2xl border border-brand-400/40 bg-brand-500/10 p-4">
-                        <h3 class="text-sm font-semibold uppercase tracking-wide text-brand-100">Erwartete Genetik</h3>
-                        <div class="rich-text-content prose prose-invert mt-3 max-w-none text-sm text-slate-100">
+<section class="section">
+    <div class="section__inner">
+        <header class="section-header">
+            <h1 class="section-header__title">Zuchtplanung</h1>
+            <p class="section-header__description">Interne Übersicht über geplante Verpaarungen, erwartete Morphs und Inkubationsschritte.</p>
+        </header>
+        <div class="highlight-deck">
+            <?php foreach ($breedingPlans as $plan): ?>
+                <article class="card card--neutral">
+                    <header>
+                        <h2 class="card__title"><?= htmlspecialchars($plan['title']) ?></h2>
+                        <p class="card__subtitle">Saison: <?= htmlspecialchars($plan['season'] ?: 'offen') ?></p>
+                    </header>
+                    <?php if (!empty($plan['expected_genetics'])): ?>
+                        <div class="rich-text-content">
+                            <h3>Erwartete Genetik</h3>
                             <?= render_rich_text($plan['expected_genetics']) ?>
                         </div>
-                    </div>
-                <?php endif; ?>
-                <?php if (!empty($plan['incubation_notes'])): ?>
-                    <div class="mt-6 rounded-2xl border border-white/10 bg-white/5 p-4">
-                        <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-200">Inkubationsnotizen</h3>
-                        <div class="rich-text-content prose prose-invert mt-3 max-w-none text-sm text-slate-100">
+                    <?php endif; ?>
+                    <?php if (!empty($plan['incubation_notes'])): ?>
+                        <div class="rich-text-content">
+                            <h3>Inkubationsnotizen</h3>
                             <?= render_rich_text($plan['incubation_notes']) ?>
                         </div>
-                    </div>
-                <?php endif; ?>
-                <?php if (!empty($plan['notes'])): ?>
-                    <div class="mt-6 rounded-2xl border border-white/10 bg-white/5 p-4">
-                        <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-200">Notizen</h3>
-                        <div class="rich-text-content prose prose-invert mt-3 max-w-none text-sm text-slate-100">
+                    <?php endif; ?>
+                    <?php if (!empty($plan['notes'])): ?>
+                        <div class="rich-text-content">
+                            <h3>Notizen</h3>
                             <?= render_rich_text($plan['notes']) ?>
                         </div>
-                    </div>
-                <?php endif; ?>
-                <h3 class="mt-8 text-lg font-semibold text-white">Elterntiere</h3>
-                <?php if (empty($plan['parents'])): ?>
-                    <p class="mt-2 text-sm text-slate-400">Noch keine Eltern hinterlegt.</p>
-                <?php else: ?>
-                    <ul class="mt-4 grid gap-4 sm:grid-cols-2">
-                        <?php foreach ($plan['parents'] as $parent): ?>
-                            <li class="rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-slate-200">
-                                <div class="flex items-center justify-between gap-3">
-                                    <strong class="text-base text-white"><?= htmlspecialchars($parent['parent_type'] === 'virtual' ? ($parent['name'] ?: 'Virtuell') : ($parent['animal_name'] ?? $parent['name'] ?? 'Unbenannt')) ?></strong>
+                    <?php endif; ?>
+                    <h3>Elterntiere</h3>
+                    <?php if (empty($plan['parents'])): ?>
+                        <p class="card__subtitle">Noch keine Eltern hinterlegt.</p>
+                    <?php else: ?>
+                        <ul class="listing-card__meta">
+                            <?php foreach ($plan['parents'] as $parent): ?>
+                                <li>
+                                    <strong><?= htmlspecialchars($parent['parent_type'] === 'virtual' ? ($parent['name'] ?: 'Virtuell') : ($parent['animal_name'] ?? $parent['name'] ?? 'Unbenannt')) ?></strong>
                                     <?php if ($parent['sex']): ?>
-                                        <span class="inline-flex items-center justify-center rounded-full border border-brand-400 bg-brand-500/20 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-brand-100"><?= htmlspecialchars(strtoupper($parent['sex'])) ?></span>
+                                        – <?= htmlspecialchars(strtoupper($parent['sex'])) ?>
                                     <?php endif; ?>
-                                </div>
-                                <p class="mt-1 text-xs uppercase tracking-wide text-slate-400">
-                                    <?= htmlspecialchars($parent['parent_type'] === 'virtual' ? 'Virtuelles Tier' : 'Bestandstier') ?>
-                                </p>
-                                <?php if ($parent['parent_type'] === 'animal' && $parent['animal_species']): ?>
-                                    <p class="mt-2 text-sm text-slate-200"><?= htmlspecialchars($parent['animal_species']) ?></p>
-                                <?php elseif (!empty($parent['species'])): ?>
-                                    <p class="mt-2 text-sm text-slate-200"><?= htmlspecialchars($parent['species']) ?></p>
-                                <?php endif; ?>
-                                <?php if (!empty($parent['animal_genetics']) || !empty($parent['genetics'])): ?>
-                                    <p class="mt-2 text-sm text-slate-200"><strong>Genetik:</strong> <?= htmlspecialchars($parent['animal_genetics'] ?? $parent['genetics']) ?></p>
-                                <?php endif; ?>
-                                <?php if (!empty($parent['notes'])): ?>
-                                    <p class="mt-2 whitespace-pre-line text-sm text-slate-200"><?= htmlspecialchars($parent['notes']) ?></p>
-                                <?php endif; ?>
-                            </li>
-                        <?php endforeach; ?>
-                    </ul>
-                <?php endif; ?>
-            </article>
-        <?php endforeach; ?>
+                                    <div>
+                                        <small><?= htmlspecialchars($parent['parent_type'] === 'virtual' ? 'Virtuelles Tier' : 'Bestandstier') ?></small>
+                                    </div>
+                                    <?php if ($parent['parent_type'] === 'animal' && $parent['animal_species']): ?>
+                                        <div><?= htmlspecialchars($parent['animal_species']) ?></div>
+                                    <?php elseif (!empty($parent['species'])): ?>
+                                        <div><?= htmlspecialchars($parent['species']) ?></div>
+                                    <?php endif; ?>
+                                    <?php if (!empty($parent['animal_genetics']) || !empty($parent['genetics'])): ?>
+                                        <div>Genetik: <?= htmlspecialchars($parent['animal_genetics'] ?? $parent['genetics']) ?></div>
+                                    <?php endif; ?>
+                                    <?php if (!empty($parent['notes'])): ?>
+                                        <div><?= nl2br(htmlspecialchars($parent['notes'])) ?></div>
+                                    <?php endif; ?>
+                                </li>
+                            <?php endforeach; ?>
+                        </ul>
+                    <?php endif; ?>
+                </article>
+            <?php endforeach; ?>
+        </div>
     </div>
 </section>
 <?php include __DIR__ . '/../partials/footer.php'; ?>
-

--- a/public/views/care/index.php
+++ b/public/views/care/index.php
@@ -1,0 +1,20 @@
+<?php include __DIR__ . '/../partials/header.php'; ?>
+<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
+    <header class="max-w-3xl">
+        <h1 class="text-3xl font-semibold text-white sm:text-4xl">Pflegeleitfaden</h1>
+        <p class="mt-2 text-sm text-slate-300">Wissensdatenbank mit Pflegeprofilen, Technik- und Ernährungsrichtlinien.</p>
+    </header>
+    <div class="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+        <?php foreach ($careArticles as $article): ?>
+            <article class="flex h-full flex-col rounded-3xl border border-white/5 bg-night-900/70 p-6 shadow-lg shadow-black/30 transition hover:border-brand-400/60 hover:shadow-glow">
+                <h2 class="text-xl font-semibold text-white"><?= htmlspecialchars($article['title']) ?></h2>
+                <?php if (!empty($article['summary'])): ?>
+                    <p class="mt-3 text-sm text-slate-200"><?= nl2br(htmlspecialchars($article['summary'])) ?></p>
+                <?php endif; ?>
+                <a class="mt-auto inline-flex items-center gap-2 rounded-full border border-brand-400/60 bg-brand-500/10 px-4 py-2 text-sm font-semibold text-brand-100 transition hover:border-brand-300 hover:bg-brand-500/20" href="<?= BASE_URL ?>/index.php?route=care-article&amp;slug=<?= urlencode($article['slug']) ?>">Artikel lesen</a>
+            </article>
+        <?php endforeach; ?>
+    </div>
+</section>
+<?php include __DIR__ . '/../partials/footer.php'; ?>
+

--- a/public/views/care/index.php
+++ b/public/views/care/index.php
@@ -1,20 +1,28 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
-<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
-    <header class="max-w-3xl">
-        <h1 class="text-3xl font-semibold text-white sm:text-4xl">Pflegeleitfaden</h1>
-        <p class="mt-2 text-sm text-slate-300">Wissensdatenbank mit Pflegeprofilen, Technik- und Ernährungsrichtlinien.</p>
-    </header>
-    <div class="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-        <?php foreach ($careArticles as $article): ?>
-            <article class="flex h-full flex-col rounded-3xl border border-white/5 bg-night-900/70 p-6 shadow-lg shadow-black/30 transition hover:border-brand-400/60 hover:shadow-glow">
-                <h2 class="text-xl font-semibold text-white"><?= htmlspecialchars($article['title']) ?></h2>
-                <?php if (!empty($article['summary'])): ?>
-                    <p class="mt-3 text-sm text-slate-200"><?= nl2br(htmlspecialchars($article['summary'])) ?></p>
-                <?php endif; ?>
-                <a class="mt-auto inline-flex items-center gap-2 rounded-full border border-brand-400/60 bg-brand-500/10 px-4 py-2 text-sm font-semibold text-brand-100 transition hover:border-brand-300 hover:bg-brand-500/20" href="<?= BASE_URL ?>/index.php?route=care-article&amp;slug=<?= urlencode($article['slug']) ?>">Artikel lesen</a>
-            </article>
-        <?php endforeach; ?>
+<section class="section">
+    <div class="section__inner">
+        <header class="section-header">
+            <h1 class="section-header__title">Pflegeleitfaden</h1>
+            <p class="section-header__description">Wissensdatenbank mit Pflegeprofilen, Technik- und Ernährungsrichtlinien für Bartagamen.</p>
+        </header>
+        <div class="card-grid">
+            <?php foreach ($careArticles as $article): ?>
+                <article class="card">
+                    <h2 class="card__title"><?= htmlspecialchars($article['title']) ?></h2>
+                    <?php if (!empty($article['summary'])): ?>
+                        <div class="rich-text-content">
+                            <p><?= nl2br(htmlspecialchars($article['summary'])) ?></p>
+                        </div>
+                    <?php endif; ?>
+                    <?php if (!empty($article['reading_time'])): ?>
+                        <p class="card__meta">Lesezeit: <?= htmlspecialchars($article['reading_time']) ?> Minuten</p>
+                    <?php endif; ?>
+                    <div class="card__cta">
+                        <a class="button button--outline" href="<?= BASE_URL ?>/index.php?route=care-article&amp;slug=<?= urlencode($article['slug']) ?>">Artikel lesen</a>
+                    </div>
+                </article>
+            <?php endforeach; ?>
+        </div>
     </div>
 </section>
 <?php include __DIR__ . '/../partials/footer.php'; ?>
-

--- a/public/views/care/show.php
+++ b/public/views/care/show.php
@@ -1,14 +1,51 @@
+<?php
+$wordCount = str_word_count(strip_tags($article['content'] ?? ''));
+$readMinutes = max(1, (int)ceil($wordCount / 200));
+$toc = [];
+$contentWithAnchors = $article['content'] ?? '';
+if ($contentWithAnchors) {
+    $contentWithAnchors = preg_replace_callback('/<h2([^>]*)>(.*?)<\/h2>/i', function ($matches) use (&$toc) {
+        $text = trim(strip_tags($matches[2]));
+        $id = slugify($text);
+        $toc[] = ['id' => $id, 'title' => $text];
+        $attributes = $matches[1];
+        if (stripos($attributes, 'id=') === false) {
+            $attributes .= ' id="' . htmlspecialchars($id, ENT_QUOTES) . '"';
+        }
+        return '<h2' . $attributes . '>' . $matches[2] . '</h2>';
+    }, $contentWithAnchors);
+}
+?>
 <?php include __DIR__ . '/../partials/header.php'; ?>
-<section class="mx-auto w-full max-w-4xl px-4 sm:px-6 lg:px-8">
-    <article class="rounded-3xl border border-white/5 bg-night-900/70 p-8 shadow-lg shadow-black/30">
-        <h1 class="text-3xl font-semibold text-white sm:text-4xl"><?= htmlspecialchars($article['title']) ?></h1>
-        <?php if (!empty($article['summary'])): ?>
-            <p class="mt-3 text-sm text-slate-300"><?= nl2br(htmlspecialchars($article['summary'])) ?></p>
-        <?php endif; ?>
-        <div class="rich-text-content prose prose-invert mt-6 max-w-none text-slate-100">
-            <?= render_rich_text($article['content']) ?>
-        </div>
-    </article>
+<section class="section">
+    <div class="section__inner">
+        <article class="article-shell">
+            <header>
+                <h1><?= htmlspecialchars($article['title']) ?></h1>
+                <div class="card__meta">
+                    <span>Lesedauer: <?= $readMinutes ?> <?= $readMinutes === 1 ? 'Minute' : 'Minuten' ?></span>
+                    <?php if (!empty($article['updated_at'])): ?>
+                        <span>Aktualisiert: <?= date('d.m.Y', strtotime($article['updated_at'])) ?></span>
+                    <?php endif; ?>
+                </div>
+                <?php if (!empty($article['summary'])): ?>
+                    <p class="section-header__description"><?= nl2br(htmlspecialchars($article['summary'])) ?></p>
+                <?php endif; ?>
+            </header>
+            <?php if (!empty($toc)): ?>
+                <aside class="highlight-card" aria-label="Inhaltsverzeichnis">
+                    <strong>Inhaltsverzeichnis</strong>
+                    <ol>
+                        <?php foreach ($toc as $item): ?>
+                            <li><a href="#<?= htmlspecialchars($item['id']) ?>"><?= htmlspecialchars($item['title']) ?></a></li>
+                        <?php endforeach; ?>
+                    </ol>
+                </aside>
+            <?php endif; ?>
+            <div class="content-prose">
+                <?= render_rich_text($contentWithAnchors) ?>
+            </div>
+        </article>
+    </div>
 </section>
 <?php include __DIR__ . '/../partials/footer.php'; ?>
-

--- a/public/views/care/show.php
+++ b/public/views/care/show.php
@@ -1,0 +1,14 @@
+<?php include __DIR__ . '/../partials/header.php'; ?>
+<section class="mx-auto w-full max-w-4xl px-4 sm:px-6 lg:px-8">
+    <article class="rounded-3xl border border-white/5 bg-night-900/70 p-8 shadow-lg shadow-black/30">
+        <h1 class="text-3xl font-semibold text-white sm:text-4xl"><?= htmlspecialchars($article['title']) ?></h1>
+        <?php if (!empty($article['summary'])): ?>
+            <p class="mt-3 text-sm text-slate-300"><?= nl2br(htmlspecialchars($article['summary'])) ?></p>
+        <?php endif; ?>
+        <div class="rich-text-content prose prose-invert mt-6 max-w-none text-slate-100">
+            <?= render_rich_text($article['content']) ?>
+        </div>
+    </article>
+</section>
+<?php include __DIR__ . '/../partials/footer.php'; ?>
+

--- a/public/views/errors/404.php
+++ b/public/views/errors/404.php
@@ -1,6 +1,13 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
-<div class="card">
-    <h1>404</h1>
-    <p>Die angeforderte Seite wurde nicht gefunden.</p>
-</div>
+<section class="section">
+    <div class="section__inner" style="max-width:480px;">
+        <article class="card">
+            <h1 class="card__title">404 – Seite nicht gefunden</h1>
+            <p class="card__subtitle">Die angeforderte Seite existiert nicht oder wurde verschoben. Bitte prüfen Sie die URL oder kehren Sie zur Startseite zurück.</p>
+            <div class="form-actions">
+                <a class="button button--outline" href="<?= BASE_URL ?>/index.php">Zur Startseite</a>
+            </div>
+        </article>
+    </div>
+</section>
 <?php include __DIR__ . '/../partials/footer.php'; ?>

--- a/public/views/genetics/index.php
+++ b/public/views/genetics/index.php
@@ -1,243 +1,230 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
-<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
-<h1 class="text-3xl font-semibold text-white sm:text-4xl">Genetikrechner</h1>
-<p class="mt-2 text-sm text-slate-300">Planen Sie Ihre Verpaarungen analog zu MorphMarket: Wählen Sie eine Art, hinterlegen Sie die Genetik beider Elternteile und erhalten Sie fundierte Wahrscheinlichkeiten für visuelle Nachzuchten sowie Trägertiere.</p>
+<section class="section">
+    <div class="section__inner">
+        <header class="section-header">
+            <h1 class="section-header__title">Genetikrechner</h1>
+            <p class="section-header__description">Planen Sie Verpaarungen mit wissenschaftlich fundierten Wahrscheinlichkeiten – wählen Sie eine Art, kombinieren Sie Gene und erhalten Sie visuelle und Träger-Ergebnisse.</p>
+        </header>
+        <?php if (empty($speciesList)): ?>
+            <article class="card">
+                <p>Aktuell sind keine genetischen Datensätze hinterlegt. Bitte melden Sie sich als Administrator an, um Arten und Gene zu pflegen.</p>
+            </article>
+        <?php else: ?>
+            <article class="card">
+                <form method="get" class="form-grid">
+                    <input type="hidden" name="route" value="genetics">
+                    <label class="label">Art auswählen
+                        <select class="select" name="species" onchange="this.form.submit()">
+                            <?php foreach ($speciesList as $species): ?>
+                                <option value="<?= htmlspecialchars($species['slug']) ?>" <?= ($selectedSpeciesSlug === $species['slug']) ? 'selected' : '' ?>><?= htmlspecialchars($species['name']) ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </label>
+                    <noscript>
+                        <button type="submit" class="button button--outline">Wechseln</button>
+                    </noscript>
+                </form>
+                <?php if ($selectedSpecies): ?>
+                    <p class="card__subtitle">Aktuelle Art: <strong><?= htmlspecialchars($selectedSpecies['name']) ?></strong><?php if (!empty($selectedSpecies['scientific_name'])): ?> (<em><?= htmlspecialchars($selectedSpecies['scientific_name']) ?></em>)<?php endif; ?></p>
+                    <?php if (!empty($selectedSpecies['description'])): ?>
+                        <div class="rich-text-content">
+                            <?= render_rich_text($selectedSpecies['description']) ?>
+                        </div>
+                    <?php endif; ?>
+                <?php endif; ?>
+            </article>
 
-<?php if (empty($speciesList)): ?>
-    <div class="card">
-        <p>Aktuell sind keine genetischen Datensätze hinterlegt. Bitte melden Sie sich als Administrator an, um Arten und Gene zu pflegen.</p>
-    </div>
-<?php else: ?>
-    <div class="card" style="margin-bottom:2rem;">
-        <form method="get" style="display:flex;gap:1rem;align-items:flex-end;flex-wrap:wrap;">
-            <input type="hidden" name="route" value="genetics">
-            <label>Art auswählen
-                <select name="species" onchange="this.form.submit()">
-                    <?php foreach ($speciesList as $species): ?>
-                        <option value="<?= htmlspecialchars($species['slug']) ?>" <?= ($selectedSpeciesSlug === $species['slug']) ? 'selected' : '' ?>><?= htmlspecialchars($species['name']) ?></option>
-                    <?php endforeach; ?>
-                </select>
-            </label>
-            <noscript>
-                <button type="submit">Wechseln</button>
-            </noscript>
-        </form>
-        <?php if ($selectedSpecies): ?>
-            <p style="margin-top:0.5rem;">Aktuelle Art: <strong><?= htmlspecialchars($selectedSpecies['name']) ?></strong><?php if (!empty($selectedSpecies['scientific_name'])): ?> (<em><?= htmlspecialchars($selectedSpecies['scientific_name']) ?></em>)<?php endif; ?></p>
-            <?php if (!empty($selectedSpecies['description'])): ?>
-                <div class="rich-text-content" style="margin-top:0.75rem;">
-                    <?= render_rich_text($selectedSpecies['description']) ?>
-                </div>
+            <?php if ($selectedSpecies && !empty($genes)): ?>
+                <?php
+                    $toLower = static function (string $value): string {
+                        return function_exists('mb_strtolower') ? mb_strtolower($value, 'UTF-8') : strtolower($value);
+                    };
+                    $modeLabels = [
+                        'recessive' => 'rezessiv',
+                        'dominant' => 'dominant',
+                        'incomplete_dominant' => 'inkomplett dominant',
+                    ];
+                    $geneStatePayload = [];
+                    foreach ($genes as $gene) {
+                        $geneId = (int)$gene['id'];
+                        $stateEntries = [];
+                        foreach (['normal', 'heterozygous', 'homozygous'] as $stateKey) {
+                            $label = gene_state_label($gene, $stateKey);
+                            $tokens = [$toLower($label), $toLower($gene['name'])];
+                            if (!empty($gene['shorthand'])) {
+                                $tokens[] = $toLower($gene['shorthand']);
+                            }
+                            if ($stateKey === 'normal') {
+                                $tokens[] = 'wildtyp';
+                                $tokens[] = 'normal ' . $toLower($gene['name']);
+                            } elseif ($stateKey === 'heterozygous') {
+                                $tokens[] = 'het ' . $toLower($gene['name']);
+                                $tokens[] = 'träger ' . $toLower($gene['name']);
+                            } else {
+                                $tokens[] = 'visual ' . $toLower($gene['name']);
+                            }
+                            $stateEntries[] = [
+                                'key' => $stateKey,
+                                'label' => $label,
+                                'searchTokens' => array_values(array_unique($tokens)),
+                            ];
+                        }
+                        $geneStatePayload[] = [
+                            'id' => $geneId,
+                            'name' => $gene['name'],
+                            'shorthand' => $gene['shorthand'],
+                            'inheritance' => $modeLabels[$gene['inheritance_mode']] ?? $gene['inheritance_mode'],
+                            'description' => $gene['description'],
+                            'states' => $stateEntries,
+                        ];
+                    }
+                ?>
+                <form method="post" class="card gene-selector" data-genetic-selector>
+                    <input type="hidden" name="species_slug" value="<?= htmlspecialchars($selectedSpecies['slug']) ?>">
+                    <header class="gene-selector__header">
+                        <h2>Elterliche Genetik eingeben</h2>
+                        <p>Tippen Sie einen Gen-Namen, wählen Sie den passenden Vorschlag und bauen Sie die vollständige Genetik beider Elternteile auf.</p>
+                    </header>
+                    <div class="alert alert-error" data-form-error hidden role="alert" aria-live="assertive"></div>
+                    <div class="gene-selector__parents">
+                        <section class="gene-parent" data-parent="parent1">
+                            <div class="gene-parent__header">
+                                <h3>Elter 1</h3>
+                                <button type="button" class="gene-parent__clear" data-clear>Leeren</button>
+                            </div>
+                            <label class="sr-only" for="genetics-parent1-input">Gene Elter 1</label>
+                            <div class="gene-multiselect" data-multiselect>
+                                <div class="gene-multiselect__body">
+                                    <div class="gene-multiselect__tags" data-placeholder="Wildtyp" data-tag-container></div>
+                                    <input id="genetics-parent1-input" type="text" placeholder="Gen hinzufügen …" autocomplete="off" data-input>
+                                </div>
+                            </div>
+                            <div class="gene-parent__suggestions" data-suggestions hidden></div>
+                            <p class="gene-parent__hint">Fügen Sie visuelle Morphe oder Trägereigenschaften wie „het Albino“ hinzu.</p>
+                            <div data-hidden-inputs></div>
+                        </section>
+                        <section class="gene-parent" data-parent="parent2">
+                            <div class="gene-parent__header">
+                                <h3>Elter 2</h3>
+                                <button type="button" class="gene-parent__clear" data-clear>Leeren</button>
+                            </div>
+                            <label class="sr-only" for="genetics-parent2-input">Gene Elter 2</label>
+                            <div class="gene-multiselect" data-multiselect>
+                                <div class="gene-multiselect__body">
+                                    <div class="gene-multiselect__tags" data-placeholder="Wildtyp" data-tag-container></div>
+                                    <input id="genetics-parent2-input" type="text" placeholder="Gen hinzufügen …" autocomplete="off" data-input>
+                                </div>
+                            </div>
+                            <div class="gene-parent__suggestions" data-suggestions hidden></div>
+                            <p class="gene-parent__hint">Jeder Eintrag wird direkt übernommen – nicht hinzugefügte Gene bleiben Wildtyp.</p>
+                            <div data-hidden-inputs></div>
+                        </section>
+                    </div>
+                    <div class="gene-selector__actions">
+                        <button type="submit" class="btn btn-primary">Berechnen</button>
+                        <button type="button" class="btn btn-secondary" data-clear-all>Zurücksetzen</button>
+                    </div>
+                </form>
+                <section class="gene-reference">
+                    <h2>Verfügbare Gene</h2>
+                    <div class="card-grid">
+                        <?php foreach ($genes as $gene): ?>
+                            <article class="card gene-reference__card">
+                                <header class="gene-reference__header">
+                                    <div>
+                                        <h3><?= htmlspecialchars($gene['name']) ?></h3>
+                                        <?php if (!empty($gene['shorthand'])): ?>
+                                            <span class="badge">Kürzel: <?= htmlspecialchars($gene['shorthand']) ?></span>
+                                        <?php endif; ?>
+                                    </div>
+                                    <span class="badge"><?= htmlspecialchars($modeLabels[$gene['inheritance_mode']] ?? $gene['inheritance_mode']) ?></span>
+                                </header>
+                                <dl class="gene-reference__states">
+                                    <div><dt>Wildtyp</dt><dd><?= htmlspecialchars(gene_state_label($gene, 'normal')) ?></dd></div>
+                                    <div><dt>Träger</dt><dd><?= htmlspecialchars(gene_state_label($gene, 'heterozygous')) ?></dd></div>
+                                    <div><dt>Visuell</dt><dd><?= htmlspecialchars(gene_state_label($gene, 'homozygous')) ?></dd></div>
+                                </dl>
+                                <?php if (!empty($gene['description'])): ?>
+                                    <p class="card__subtitle"><?= htmlspecialchars($gene['description']) ?></p>
+                                <?php endif; ?>
+                            </article>
+                        <?php endforeach; ?>
+                    </div>
+                </section>
+                <script>
+                    window.GENETIC_GENE_DATA = <?= json_encode($geneStatePayload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?>;
+                    window.GENETIC_PARENT_SELECTIONS = <?= json_encode($parentSelections, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?>;
+                </script>
+            <?php elseif ($selectedSpecies): ?>
+                <article class="card">
+                    <p>Für diese Art wurden bislang keine Gene hinterlegt.</p>
+                </article>
+            <?php endif; ?>
+
+            <?php if ($selectedSpecies): ?>
+                <section class="gene-results">
+                    <div class="card gene-results__card">
+                        <?php if (!empty($results)): ?>
+                            <table class="gene-results__table">
+                                <thead>
+                                    <tr>
+                                        <th>Wahrscheinlichkeit</th>
+                                        <th>Traits</th>
+                                        <th>Morph</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <?php foreach ($results['combined'] as $entry): ?>
+                                        <?php
+                                            $fraction = probability_to_fraction_components($entry['probability']);
+                                            $tags = [];
+                                            $morphParts = [];
+                                            foreach ($entry['states'] as $geneId => $stateKey) {
+                                                $geneResult = $results['genes'][$geneId] ?? null;
+                                                if (!$geneResult) {
+                                                    continue;
+                                                }
+                                                $gene = $geneResult['gene'];
+                                                $label = $entry['labels'][$geneId] ?? gene_state_label($gene, $stateKey);
+                                                if (gene_state_is_visual($gene, $stateKey)) {
+                                                    $tags[] = ['label' => $label, 'type' => 'visual'];
+                                                    $morphParts[] = $label;
+                                                } elseif (gene_state_is_carrier($gene, $stateKey)) {
+                                                    $tags[] = ['label' => $label, 'type' => 'carrier'];
+                                                    $clean = trim(preg_replace('/^het\s+/i', '', $label));
+                                                    $morphParts[] = 'Het ' . ($clean !== '' ? $clean : $gene['name']);
+                                                }
+                                            }
+                                            $morphName = empty($morphParts) ? 'Wildtyp' : implode(' ', $morphParts);
+                                        ?>
+                                        <tr>
+                                            <td>
+                                                <span class="gene-results__fraction"><?= $fraction['numerator'] ?>/<?= $fraction['denominator'] ?></span>
+                                                <span class="gene-results__percentage"><?= number_format($fraction['percentage'], 1, ',', '.') ?>%</span>
+                                            </td>
+                                            <td>
+                                                <?php if (!empty($tags)): ?>
+                                                    <div class="gene-results__tags">
+                                                        <?php foreach ($tags as $tag): ?>
+                                                            <span class="gene-pill gene-pill--<?= $tag['type'] ?>"><?= htmlspecialchars($tag['label']) ?></span>
+                                                        <?php endforeach; ?>
+                                                    </div>
+                                                <?php else: ?>
+                                                    <span class="gene-results__placeholder">Wildtyp</span>
+                                                <?php endif; ?>
+                                            </td>
+                                            <td><span class="gene-results__morph"><?= htmlspecialchars($morphName) ?></span></td>
+                                        </tr>
+                                    <?php endforeach; ?>
+                                </tbody>
+                            </table>
+                        <?php else: ?>
+                            <div class="gene-results__empty" role="status">Bitte Genetik oben zusammenstellen, um eine Auswertung zu erhalten.</div>
+                        <?php endif; ?>
+                    </div>
+                </section>
             <?php endif; ?>
         <?php endif; ?>
     </div>
-
-    <?php if ($selectedSpecies && !empty($genes)): ?>
-        <?php
-            $toLower = static function (string $value): string {
-                return function_exists('mb_strtolower') ? mb_strtolower($value, 'UTF-8') : strtolower($value);
-            };
-            $modeLabels = [
-                'recessive' => 'rezessiv',
-                'dominant' => 'dominant',
-                'incomplete_dominant' => 'inkomplett dominant',
-            ];
-            $geneStatePayload = [];
-            foreach ($genes as $gene) {
-                $geneId = (int)$gene['id'];
-                $stateEntries = [];
-                foreach (['normal', 'heterozygous', 'homozygous'] as $stateKey) {
-                    $label = gene_state_label($gene, $stateKey);
-                    $tokens = [$toLower($label), $toLower($gene['name'])];
-                    if (!empty($gene['shorthand'])) {
-                        $tokens[] = $toLower($gene['shorthand']);
-                    }
-                    if ($stateKey === 'normal') {
-                        $tokens[] = 'wildtyp';
-                        $tokens[] = 'normal ' . $toLower($gene['name']);
-                    } elseif ($stateKey === 'heterozygous') {
-                        $tokens[] = 'het ' . $toLower($gene['name']);
-                        $tokens[] = 'träger ' . $toLower($gene['name']);
-                    } else {
-                        $tokens[] = 'visual ' . $toLower($gene['name']);
-                    }
-                    $stateEntries[] = [
-                        'key' => $stateKey,
-                        'label' => $label,
-                        'searchTokens' => array_values(array_unique($tokens)),
-                    ];
-                }
-                $geneStatePayload[] = [
-                    'id' => $geneId,
-                    'name' => $gene['name'],
-                    'shorthand' => $gene['shorthand'],
-                    'inheritance' => $modeLabels[$gene['inheritance_mode']] ?? $gene['inheritance_mode'],
-                    'description' => $gene['description'],
-                    'states' => $stateEntries,
-                ];
-            }
-        ?>
-        <form method="post" class="card gene-selector" data-genetic-selector>
-            <input type="hidden" name="species_slug" value="<?= htmlspecialchars($selectedSpecies['slug']) ?>">
-            <header class="gene-selector__header">
-                <h2>Elterliche Genetik eingeben</h2>
-                <p>Tippen Sie einen Gen-Namen, wählen Sie den passenden Vorschlag und bauen Sie die vollständige Genetik beider Elternteile auf.</p>
-            </header>
-            <div class="alert alert-error" data-form-error hidden role="alert" aria-live="assertive"></div>
-            <div class="gene-selector__parents">
-                <section class="gene-parent" data-parent="parent1">
-                    <div class="gene-parent__header">
-                        <h3>Elter 1</h3>
-                        <button type="button" class="gene-parent__clear" data-clear>Leeren</button>
-                    </div>
-                    <label class="sr-only" for="genetics-parent1-input">Gene Elter 1</label>
-                    <div class="gene-multiselect" data-multiselect>
-                        <div class="gene-multiselect__body">
-                            <div class="gene-multiselect__tags" data-placeholder="Wildtyp" data-tag-container></div>
-                            <input id="genetics-parent1-input" type="text" placeholder="Gen hinzufügen …" autocomplete="off" data-input>
-                        </div>
-                    </div>
-                    <div class="gene-parent__suggestions" data-suggestions hidden></div>
-                    <p class="gene-parent__hint">Fügen Sie visuelle Morphe oder Trägereigenschaften wie „het Albino“ hinzu.</p>
-                    <div data-hidden-inputs></div>
-                </section>
-                <section class="gene-parent" data-parent="parent2">
-                    <div class="gene-parent__header">
-                        <h3>Elter 2</h3>
-                        <button type="button" class="gene-parent__clear" data-clear>Leeren</button>
-                    </div>
-                    <label class="sr-only" for="genetics-parent2-input">Gene Elter 2</label>
-                    <div class="gene-multiselect" data-multiselect>
-                        <div class="gene-multiselect__body">
-                            <div class="gene-multiselect__tags" data-placeholder="Wildtyp" data-tag-container></div>
-                            <input id="genetics-parent2-input" type="text" placeholder="Gen hinzufügen …" autocomplete="off" data-input>
-                        </div>
-                    </div>
-                    <div class="gene-parent__suggestions" data-suggestions hidden></div>
-                    <p class="gene-parent__hint">Jeder Eintrag wird direkt übernommen – nicht hinzugefügte Gene bleiben Wildtyp.</p>
-                    <div data-hidden-inputs></div>
-                </section>
-            </div>
-            <div class="gene-selector__actions">
-                <button type="submit" class="btn">Berechnen</button>
-                <button type="button" class="btn btn-secondary" data-clear-all>Zurücksetzen</button>
-            </div>
-        </form>
-        <section class="gene-reference">
-            <h2>Verfügbare Gene</h2>
-            <div class="grid cards">
-                <?php foreach ($genes as $gene): ?>
-                    <article class="card gene-reference__card">
-                        <header class="gene-reference__header">
-                            <div>
-                                <h3><?= htmlspecialchars($gene['name']) ?></h3>
-                                <?php if (!empty($gene['shorthand'])): ?>
-                                    <span class="badge">Kürzel: <?= htmlspecialchars($gene['shorthand']) ?></span>
-                                <?php endif; ?>
-                            </div>
-                            <span class="badge"><?= htmlspecialchars($modeLabels[$gene['inheritance_mode']] ?? $gene['inheritance_mode']) ?></span>
-                        </header>
-                        <dl class="gene-reference__states">
-                            <div><dt>Wildtyp</dt><dd><?= htmlspecialchars(gene_state_label($gene, 'normal')) ?></dd></div>
-                            <div><dt>Träger</dt><dd><?= htmlspecialchars(gene_state_label($gene, 'heterozygous')) ?></dd></div>
-                            <div><dt>Visuell</dt><dd><?= htmlspecialchars(gene_state_label($gene, 'homozygous')) ?></dd></div>
-                        </dl>
-                        <?php if (!empty($gene['description'])): ?>
-                            <p class="text-muted" style="line-height:1.5;"><?= htmlspecialchars($gene['description']) ?></p>
-                        <?php endif; ?>
-                    </article>
-                <?php endforeach; ?>
-            </div>
-        </section>
-        <script>
-            window.GENETIC_GENE_DATA = <?= json_encode($geneStatePayload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?>;
-            window.GENETIC_PARENT_SELECTIONS = <?= json_encode($parentSelections, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?>;
-        </script>
-    <?php elseif ($selectedSpecies): ?>
-        <div class="card" style="margin-bottom:2rem;">
-            <p>Für diese Art wurden bislang keine Gene hinterlegt.</p>
-        </div>
-    <?php endif; ?>
-
-    <?php if ($selectedSpecies): ?>
-        <section class="gene-results">
-            <div class="card gene-results__card">
-                <?php if (!empty($results)): ?>
-                    <table class="gene-results__table">
-                        <thead>
-                            <tr>
-                                <th>Prob.</th>
-                                <th>Traits</th>
-                                <th>Morph</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <?php foreach ($results['combined'] as $entry): ?>
-                                <?php
-                                    $fraction = probability_to_fraction_components($entry['probability']);
-                                    $tags = [];
-                                    $morphParts = [];
-                                    foreach ($entry['states'] as $geneId => $stateKey) {
-                                        $geneResult = $results['genes'][$geneId] ?? null;
-                                        if (!$geneResult) {
-                                            continue;
-                                        }
-                                        $gene = $geneResult['gene'];
-                                        $label = $entry['labels'][$geneId] ?? gene_state_label($gene, $stateKey);
-                                        if (gene_state_is_visual($gene, $stateKey)) {
-                                            $tags[] = ['label' => $label, 'type' => 'visual'];
-                                            $morphParts[] = $label;
-                                        } elseif (gene_state_is_carrier($gene, $stateKey)) {
-                                            $tags[] = ['label' => $label, 'type' => 'carrier'];
-                                            $clean = trim(preg_replace('/^het\s+/i', '', $label));
-                                            $morphParts[] = 'Het ' . ($clean !== '' ? $clean : $gene['name']);
-                                        }
-                                    }
-                                    if (empty($morphParts)) {
-                                        $morphName = 'Wildtyp';
-                                    } else {
-                                        $morphName = implode(' ', $morphParts);
-                                    }
-                                ?>
-                                <tr>
-                                    <td>
-                                        <span class="gene-results__fraction"><?= $fraction['numerator'] ?>/<?= $fraction['denominator'] ?></span>
-                                        <span class="gene-results__percentage"><?= number_format($fraction['percentage'], 1, ',', '.') ?>%</span>
-                                    </td>
-                                    <td>
-                                        <?php if (!empty($tags)): ?>
-                                            <div class="gene-results__tags">
-                                                <?php foreach ($tags as $tag): ?>
-                                                    <span class="gene-pill gene-pill--<?= $tag['type'] ?>"><?= htmlspecialchars($tag['label']) ?></span>
-                                                <?php endforeach; ?>
-                                            </div>
-                                        <?php else: ?>
-                                            <span class="gene-results__placeholder">Wildtyp</span>
-                                        <?php endif; ?>
-                                    </td>
-                                    <td>
-                                        <span class="gene-results__morph"><?= htmlspecialchars($morphName) ?></span>
-                                    </td>
-                                </tr>
-                            <?php endforeach; ?>
-                        </tbody>
-                    </table>
-                <?php else: ?>
-                    <div class="gene-results__empty" role="status">
-                        <h3>Noch keine Ergebnisse</h3>
-                        <p>
-                            <?php if ($_SERVER['REQUEST_METHOD'] === 'POST'): ?>
-                                Bitte wählen Sie mindestens ein Gen mit Träger- oder visueller Ausprägung aus, um Ergebnisse zu erhalten.
-                            <?php else: ?>
-                                Erfassen Sie die Genetik beider Elternteile und starten Sie die Berechnung.
-                            <?php endif; ?>
-                        </p>
-                    </div>
-                <?php endif; ?>
-            </div>
-        </section>
-    <?php endif; ?>
-<?php endif; ?>
-
 </section>
 <?php include __DIR__ . '/../partials/footer.php'; ?>

--- a/public/views/genetics/index.php
+++ b/public/views/genetics/index.php
@@ -1,0 +1,243 @@
+<?php include __DIR__ . '/../partials/header.php'; ?>
+<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
+<h1 class="text-3xl font-semibold text-white sm:text-4xl">Genetikrechner</h1>
+<p class="mt-2 text-sm text-slate-300">Planen Sie Ihre Verpaarungen analog zu MorphMarket: Wählen Sie eine Art, hinterlegen Sie die Genetik beider Elternteile und erhalten Sie fundierte Wahrscheinlichkeiten für visuelle Nachzuchten sowie Trägertiere.</p>
+
+<?php if (empty($speciesList)): ?>
+    <div class="card">
+        <p>Aktuell sind keine genetischen Datensätze hinterlegt. Bitte melden Sie sich als Administrator an, um Arten und Gene zu pflegen.</p>
+    </div>
+<?php else: ?>
+    <div class="card" style="margin-bottom:2rem;">
+        <form method="get" style="display:flex;gap:1rem;align-items:flex-end;flex-wrap:wrap;">
+            <input type="hidden" name="route" value="genetics">
+            <label>Art auswählen
+                <select name="species" onchange="this.form.submit()">
+                    <?php foreach ($speciesList as $species): ?>
+                        <option value="<?= htmlspecialchars($species['slug']) ?>" <?= ($selectedSpeciesSlug === $species['slug']) ? 'selected' : '' ?>><?= htmlspecialchars($species['name']) ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </label>
+            <noscript>
+                <button type="submit">Wechseln</button>
+            </noscript>
+        </form>
+        <?php if ($selectedSpecies): ?>
+            <p style="margin-top:0.5rem;">Aktuelle Art: <strong><?= htmlspecialchars($selectedSpecies['name']) ?></strong><?php if (!empty($selectedSpecies['scientific_name'])): ?> (<em><?= htmlspecialchars($selectedSpecies['scientific_name']) ?></em>)<?php endif; ?></p>
+            <?php if (!empty($selectedSpecies['description'])): ?>
+                <div class="rich-text-content" style="margin-top:0.75rem;">
+                    <?= render_rich_text($selectedSpecies['description']) ?>
+                </div>
+            <?php endif; ?>
+        <?php endif; ?>
+    </div>
+
+    <?php if ($selectedSpecies && !empty($genes)): ?>
+        <?php
+            $toLower = static function (string $value): string {
+                return function_exists('mb_strtolower') ? mb_strtolower($value, 'UTF-8') : strtolower($value);
+            };
+            $modeLabels = [
+                'recessive' => 'rezessiv',
+                'dominant' => 'dominant',
+                'incomplete_dominant' => 'inkomplett dominant',
+            ];
+            $geneStatePayload = [];
+            foreach ($genes as $gene) {
+                $geneId = (int)$gene['id'];
+                $stateEntries = [];
+                foreach (['normal', 'heterozygous', 'homozygous'] as $stateKey) {
+                    $label = gene_state_label($gene, $stateKey);
+                    $tokens = [$toLower($label), $toLower($gene['name'])];
+                    if (!empty($gene['shorthand'])) {
+                        $tokens[] = $toLower($gene['shorthand']);
+                    }
+                    if ($stateKey === 'normal') {
+                        $tokens[] = 'wildtyp';
+                        $tokens[] = 'normal ' . $toLower($gene['name']);
+                    } elseif ($stateKey === 'heterozygous') {
+                        $tokens[] = 'het ' . $toLower($gene['name']);
+                        $tokens[] = 'träger ' . $toLower($gene['name']);
+                    } else {
+                        $tokens[] = 'visual ' . $toLower($gene['name']);
+                    }
+                    $stateEntries[] = [
+                        'key' => $stateKey,
+                        'label' => $label,
+                        'searchTokens' => array_values(array_unique($tokens)),
+                    ];
+                }
+                $geneStatePayload[] = [
+                    'id' => $geneId,
+                    'name' => $gene['name'],
+                    'shorthand' => $gene['shorthand'],
+                    'inheritance' => $modeLabels[$gene['inheritance_mode']] ?? $gene['inheritance_mode'],
+                    'description' => $gene['description'],
+                    'states' => $stateEntries,
+                ];
+            }
+        ?>
+        <form method="post" class="card gene-selector" data-genetic-selector>
+            <input type="hidden" name="species_slug" value="<?= htmlspecialchars($selectedSpecies['slug']) ?>">
+            <header class="gene-selector__header">
+                <h2>Elterliche Genetik eingeben</h2>
+                <p>Tippen Sie einen Gen-Namen, wählen Sie den passenden Vorschlag und bauen Sie die vollständige Genetik beider Elternteile auf.</p>
+            </header>
+            <div class="alert alert-error" data-form-error hidden role="alert" aria-live="assertive"></div>
+            <div class="gene-selector__parents">
+                <section class="gene-parent" data-parent="parent1">
+                    <div class="gene-parent__header">
+                        <h3>Elter 1</h3>
+                        <button type="button" class="gene-parent__clear" data-clear>Leeren</button>
+                    </div>
+                    <label class="sr-only" for="genetics-parent1-input">Gene Elter 1</label>
+                    <div class="gene-multiselect" data-multiselect>
+                        <div class="gene-multiselect__body">
+                            <div class="gene-multiselect__tags" data-placeholder="Wildtyp" data-tag-container></div>
+                            <input id="genetics-parent1-input" type="text" placeholder="Gen hinzufügen …" autocomplete="off" data-input>
+                        </div>
+                    </div>
+                    <div class="gene-parent__suggestions" data-suggestions hidden></div>
+                    <p class="gene-parent__hint">Fügen Sie visuelle Morphe oder Trägereigenschaften wie „het Albino“ hinzu.</p>
+                    <div data-hidden-inputs></div>
+                </section>
+                <section class="gene-parent" data-parent="parent2">
+                    <div class="gene-parent__header">
+                        <h3>Elter 2</h3>
+                        <button type="button" class="gene-parent__clear" data-clear>Leeren</button>
+                    </div>
+                    <label class="sr-only" for="genetics-parent2-input">Gene Elter 2</label>
+                    <div class="gene-multiselect" data-multiselect>
+                        <div class="gene-multiselect__body">
+                            <div class="gene-multiselect__tags" data-placeholder="Wildtyp" data-tag-container></div>
+                            <input id="genetics-parent2-input" type="text" placeholder="Gen hinzufügen …" autocomplete="off" data-input>
+                        </div>
+                    </div>
+                    <div class="gene-parent__suggestions" data-suggestions hidden></div>
+                    <p class="gene-parent__hint">Jeder Eintrag wird direkt übernommen – nicht hinzugefügte Gene bleiben Wildtyp.</p>
+                    <div data-hidden-inputs></div>
+                </section>
+            </div>
+            <div class="gene-selector__actions">
+                <button type="submit" class="btn">Berechnen</button>
+                <button type="button" class="btn btn-secondary" data-clear-all>Zurücksetzen</button>
+            </div>
+        </form>
+        <section class="gene-reference">
+            <h2>Verfügbare Gene</h2>
+            <div class="grid cards">
+                <?php foreach ($genes as $gene): ?>
+                    <article class="card gene-reference__card">
+                        <header class="gene-reference__header">
+                            <div>
+                                <h3><?= htmlspecialchars($gene['name']) ?></h3>
+                                <?php if (!empty($gene['shorthand'])): ?>
+                                    <span class="badge">Kürzel: <?= htmlspecialchars($gene['shorthand']) ?></span>
+                                <?php endif; ?>
+                            </div>
+                            <span class="badge"><?= htmlspecialchars($modeLabels[$gene['inheritance_mode']] ?? $gene['inheritance_mode']) ?></span>
+                        </header>
+                        <dl class="gene-reference__states">
+                            <div><dt>Wildtyp</dt><dd><?= htmlspecialchars(gene_state_label($gene, 'normal')) ?></dd></div>
+                            <div><dt>Träger</dt><dd><?= htmlspecialchars(gene_state_label($gene, 'heterozygous')) ?></dd></div>
+                            <div><dt>Visuell</dt><dd><?= htmlspecialchars(gene_state_label($gene, 'homozygous')) ?></dd></div>
+                        </dl>
+                        <?php if (!empty($gene['description'])): ?>
+                            <p class="text-muted" style="line-height:1.5;"><?= htmlspecialchars($gene['description']) ?></p>
+                        <?php endif; ?>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+        </section>
+        <script>
+            window.GENETIC_GENE_DATA = <?= json_encode($geneStatePayload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?>;
+            window.GENETIC_PARENT_SELECTIONS = <?= json_encode($parentSelections, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?>;
+        </script>
+    <?php elseif ($selectedSpecies): ?>
+        <div class="card" style="margin-bottom:2rem;">
+            <p>Für diese Art wurden bislang keine Gene hinterlegt.</p>
+        </div>
+    <?php endif; ?>
+
+    <?php if ($selectedSpecies): ?>
+        <section class="gene-results">
+            <div class="card gene-results__card">
+                <?php if (!empty($results)): ?>
+                    <table class="gene-results__table">
+                        <thead>
+                            <tr>
+                                <th>Prob.</th>
+                                <th>Traits</th>
+                                <th>Morph</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php foreach ($results['combined'] as $entry): ?>
+                                <?php
+                                    $fraction = probability_to_fraction_components($entry['probability']);
+                                    $tags = [];
+                                    $morphParts = [];
+                                    foreach ($entry['states'] as $geneId => $stateKey) {
+                                        $geneResult = $results['genes'][$geneId] ?? null;
+                                        if (!$geneResult) {
+                                            continue;
+                                        }
+                                        $gene = $geneResult['gene'];
+                                        $label = $entry['labels'][$geneId] ?? gene_state_label($gene, $stateKey);
+                                        if (gene_state_is_visual($gene, $stateKey)) {
+                                            $tags[] = ['label' => $label, 'type' => 'visual'];
+                                            $morphParts[] = $label;
+                                        } elseif (gene_state_is_carrier($gene, $stateKey)) {
+                                            $tags[] = ['label' => $label, 'type' => 'carrier'];
+                                            $clean = trim(preg_replace('/^het\s+/i', '', $label));
+                                            $morphParts[] = 'Het ' . ($clean !== '' ? $clean : $gene['name']);
+                                        }
+                                    }
+                                    if (empty($morphParts)) {
+                                        $morphName = 'Wildtyp';
+                                    } else {
+                                        $morphName = implode(' ', $morphParts);
+                                    }
+                                ?>
+                                <tr>
+                                    <td>
+                                        <span class="gene-results__fraction"><?= $fraction['numerator'] ?>/<?= $fraction['denominator'] ?></span>
+                                        <span class="gene-results__percentage"><?= number_format($fraction['percentage'], 1, ',', '.') ?>%</span>
+                                    </td>
+                                    <td>
+                                        <?php if (!empty($tags)): ?>
+                                            <div class="gene-results__tags">
+                                                <?php foreach ($tags as $tag): ?>
+                                                    <span class="gene-pill gene-pill--<?= $tag['type'] ?>"><?= htmlspecialchars($tag['label']) ?></span>
+                                                <?php endforeach; ?>
+                                            </div>
+                                        <?php else: ?>
+                                            <span class="gene-results__placeholder">Wildtyp</span>
+                                        <?php endif; ?>
+                                    </td>
+                                    <td>
+                                        <span class="gene-results__morph"><?= htmlspecialchars($morphName) ?></span>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                <?php else: ?>
+                    <div class="gene-results__empty" role="status">
+                        <h3>Noch keine Ergebnisse</h3>
+                        <p>
+                            <?php if ($_SERVER['REQUEST_METHOD'] === 'POST'): ?>
+                                Bitte wählen Sie mindestens ein Gen mit Träger- oder visueller Ausprägung aus, um Ergebnisse zu erhalten.
+                            <?php else: ?>
+                                Erfassen Sie die Genetik beider Elternteile und starten Sie die Berechnung.
+                            <?php endif; ?>
+                        </p>
+                    </div>
+                <?php endif; ?>
+            </div>
+        </section>
+    <?php endif; ?>
+<?php endif; ?>
+
+</section>
+<?php include __DIR__ . '/../partials/footer.php'; ?>

--- a/public/views/home.php
+++ b/public/views/home.php
@@ -1,158 +1,237 @@
 <?php include __DIR__ . '/partials/header.php'; ?>
-<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
-    <div class="grid gap-10 rounded-3xl border border-white/5 bg-night-900/70 p-8 shadow-glow shadow-brand-600/20 lg:grid-cols-2">
-        <div class="space-y-6">
-            <h1 class="text-3xl font-semibold text-white sm:text-4xl lg:text-5xl"><?= htmlspecialchars($settings['site_title'] ?? APP_NAME) ?></h1>
-            <div class="rich-text-content prose prose-invert max-w-none">
-                <?= render_rich_text($settings['hero_intro'] ?? '') ?>
+<section class="section section--hero">
+    <div class="section__inner">
+        <div class="hero-panel">
+            <span class="hero-panel__kicker">FeroxZ Reptile Center</span>
+            <h1 class="hero-panel__title">Ein Zuhause für starke Bartagamen-Erfahrungen</h1>
+            <div class="hero-panel__body rich-text-content">
+                <?= render_rich_text($settings['hero_intro'] ?? 'Verantwortungsvolle Zucht, seriöse Vermittlung und wissenschaftlich geprüfte Pflegeleitfäden für Pogona vitticeps und andere Reptilienarten.') ?>
+            </div>
+            <ul class="hero-panel__bullets">
+                <li>
+                    <span aria-hidden="true"></span>
+                    <span>Transparente Haltungs- und Übergabekriterien mit Gesundheitschecks und CITES-Hinweisen.</span>
+                </li>
+                <li>
+                    <span aria-hidden="true"></span>
+                    <span>Evidenzbasierte Pflegeleitfäden – strukturiert nach Lebensphase, Ernährung und Lichtbedarf.</span>
+                </li>
+                <li>
+                    <span aria-hidden="true"></span>
+                    <span>Genetik-Tools für verantwortungsvolle Zuchtplanung und Morph-Dokumentation.</span>
+                </li>
+            </ul>
+            <div class="hero-actions">
+                <a href="<?= BASE_URL ?>/index.php?route=care-guide" class="button button--primary">Pflegeleitfaden Bartagame</a>
+                <?php if (!empty($featureGeneticsTeaser)): ?>
+                    <a href="<?= BASE_URL ?>/index.php?route=genetics" class="button button--outline">Genetik-Rechner</a>
+                <?php endif; ?>
+                <a href="<?= BASE_URL ?>/index.php?route=adoption" class="button button--outline">Abgabetiere ansehen</a>
             </div>
         </div>
-        <div class="space-y-6">
-            <span class="inline-flex items-center gap-2 rounded-full border border-brand-400/60 bg-brand-500/10 px-4 py-2 text-sm font-semibold uppercase tracking-wide text-brand-100">Pflegeleitfaden</span>
-            <p class="text-base leading-relaxed text-slate-300">
-                Unsere Leitfäden decken Beleuchtung, Ernährung, Habitatgestaltung und Gesundheitsvorsorge für
-                <strong>Pogona vitticeps</strong> und <strong>Heterodon nasicus</strong> ab. Registrierte Benutzer erhalten
-                Zugriff auf individuelle Tierakten inklusive Genetik und Besonderheiten.
-            </p>
-            <div class="grid gap-3 sm:grid-cols-2">
-                <a href="<?= BASE_URL ?>/index.php?route=care-guide" class="flex items-center justify-between rounded-2xl border border-brand-400/50 bg-brand-500/10 px-4 py-3 text-sm font-semibold text-brand-100 shadow-glow transition hover:border-brand-300 hover:bg-brand-500/20">Pflegewissen entdecken <span aria-hidden="true">→</span></a>
-                <a href="<?= BASE_URL ?>/index.php?route=genetics" class="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-semibold text-slate-100 transition hover:border-brand-300 hover:text-brand-100">Genetik-Rechner starten <span aria-hidden="true">→</span></a>
+        <div class="hero-metrics">
+            <div class="metric-card">
+                <span class="metric-card__title">Aktuelle Kennzahlen</span>
+                <div class="metric-card__grid">
+                    <div class="metric-card__item">
+                        <span>Pflegeguides online</span>
+                        <span class="metric-card__value"><?= count($careHighlights) ?></span>
+                    </div>
+                    <div class="metric-card__item">
+                        <span>Aktive Tiere im Bestand</span>
+                        <span class="metric-card__value"><?= count($animals) ?></span>
+                    </div>
+                    <div class="metric-card__item">
+                        <span>Offene Vermittlungen</span>
+                        <span class="metric-card__value"><?= count($listings) ?></span>
+                    </div>
+                </div>
+            </div>
+            <div class="metric-card">
+                <div class="metric-card__context">
+                    Bei Fragen rund um Haltung, Übergabe oder genetische Kombinationen erreichen Sie uns unter
+                    <a href="mailto:<?= htmlspecialchars($settings['contact_email'] ?? CONTACT_EMAIL) ?>"><?= htmlspecialchars($settings['contact_email'] ?? CONTACT_EMAIL) ?></a>.
+                </div>
             </div>
         </div>
     </div>
 </section>
 
 <?php if (!empty($animals)): ?>
-<section class="mx-auto mt-16 w-full max-w-7xl px-4 sm:px-6 lg:px-8">
-    <div class="flex items-center justify-between">
-        <h2 class="text-2xl font-semibold text-white sm:text-3xl">Unsere Highlights</h2>
-        <span class="text-sm text-slate-400">Ausgewählte Tiere aus dem Bestand</span>
-    </div>
-    <div class="mt-8 grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
-        <?php foreach ($animals as $animal): ?>
-            <article class="group flex h-full flex-col rounded-3xl border border-white/5 bg-night-900/70 shadow-xl shadow-black/40 transition hover:border-brand-400/60 hover:shadow-glow">
-                <?php if (!empty($animal['image_path'])): ?>
-                    <img src="<?= BASE_URL . '/' . htmlspecialchars($animal['image_path']) ?>" alt="<?= htmlspecialchars($animal['name']) ?>" class="h-52 w-full rounded-t-3xl object-cover" loading="lazy">
-                <?php endif; ?>
-                <div class="flex flex-1 flex-col gap-3 p-6">
-                    <h3 class="text-xl font-semibold text-white">
+<section class="section">
+    <div class="section__inner">
+        <header class="section-header">
+            <h2 class="section-header__title">Unsere Highlights</h2>
+            <p class="section-header__description">Ausgewählte Tiere aus dem Bestand – morphologisch dokumentiert und gesundheitsgecheckt.</p>
+        </header>
+        <div class="card-grid">
+            <?php foreach ($animals as $animal): ?>
+                <article class="card card--highlight" id="animal-<?= (int)$animal['id'] ?>">
+                    <?php if (!empty($animal['image_path'])): ?>
+                        <div class="card__media">
+                            <?= render_responsive_picture($animal['image_path'], $animal['name'] . ' – ' . $animal['species'], [
+                                'sizes' => '(max-width: 768px) 100vw, 420px',
+                            ]) ?>
+                        </div>
+                    <?php endif; ?>
+                    <h3 class="card__title">
                         <?= htmlspecialchars($animal['name']) ?>
                         <?php if (!empty($animal['is_piebald'])): ?>
-                            <span class="ml-2 inline-flex items-center justify-center rounded-full border border-brand-400 bg-brand-500/20 px-2 py-0.5 text-xs font-semibold uppercase tracking-wider text-brand-100" title="Geschecktes Tier" aria-label="Geschecktes Tier">Gescheckt</span>
+                            <span class="badge" title="Geschecktes Tier" aria-label="Geschecktes Tier">Gescheckt</span>
                         <?php endif; ?>
                     </h3>
-                    <p class="text-sm text-slate-300"><?= htmlspecialchars($animal['species']) ?></p>
+                    <p class="card__subtitle"><?= htmlspecialchars($animal['species']) ?></p>
+                    <?php if ($badge = render_sex_badge($animal['sex'] ?? null, ['class' => 'badge-gender--inline'])): ?>
+                        <?= $badge ?>
+                    <?php endif; ?>
                     <?php if (!empty($animal['genetics'])): ?>
-                        <div class="rounded-2xl border border-brand-400/30 bg-brand-500/5 px-3 py-2 text-sm text-brand-100">
-                            <span class="font-semibold uppercase tracking-wide">Genetik:</span>
-                            <?= htmlspecialchars($animal['genetics']) ?>
+                        <div class="card__meta">
+                            <span>Genetik: <?= htmlspecialchars($animal['genetics']) ?></span>
                         </div>
                     <?php endif; ?>
                     <?php if (!empty($animal['special_notes'])): ?>
-                        <div class="rich-text-content prose prose-invert max-w-none text-sm text-slate-200">
+                        <div class="rich-text-content">
                             <?= render_rich_text($animal['special_notes']) ?>
                         </div>
                     <?php endif; ?>
-                </div>
-            </article>
-        <?php endforeach; ?>
+                </article>
+            <?php endforeach; ?>
+        </div>
     </div>
 </section>
 <?php endif; ?>
 
-<section class="mx-auto mt-16 w-full max-w-7xl px-4 sm:px-6 lg:px-8">
-    <div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-            <h2 class="text-2xl font-semibold text-white sm:text-3xl">Tiervermittlung</h2>
-            <p class="text-sm text-slate-400">Aktuelle Vermittlungstiere und Kontakte</p>
+<section class="section section--stripe">
+    <div class="section__inner">
+        <header class="section-header">
+            <h2 class="section-header__title">Tiervermittlung</h2>
+            <p class="section-header__description">Aktuelle Vermittlungstiere inklusive Standort, Gesundheitsstatus und Übergabemodalitäten.</p>
+        </header>
+        <div class="rich-text-content">
+            <?= render_rich_text($settings['adoption_intro'] ?? '') ?>
         </div>
-        <?php if (!empty($settings['contact_email'])): ?>
-            <a href="mailto:<?= htmlspecialchars($settings['contact_email']) ?>" class="inline-flex items-center gap-2 rounded-full border border-brand-400/60 bg-brand-500/10 px-4 py-2 text-sm font-semibold text-brand-100 shadow-glow transition hover:border-brand-300 hover:bg-brand-500/20">
-                Kontakt aufnehmen
-            </a>
+        <?php if (!empty($listings)): ?>
+            <div class="listing-grid">
+                <?php foreach ($listings as $listing): ?>
+                    <article class="listing-card">
+                        <?php if (!empty($listing['image_path'])): ?>
+                            <div class="card__media">
+                                <?= render_responsive_picture($listing['image_path'], $listing['title'], [
+                                    'sizes' => '(max-width: 768px) 100vw, 360px',
+                                ]) ?>
+                            </div>
+                        <?php endif; ?>
+                        <h3 class="card__title"><?= htmlspecialchars($listing['title']) ?></h3>
+                        <?php if ($badge = render_sex_badge($listing['sex'] ?? null, ['class' => 'badge-gender--inline'])): ?>
+                            <?= $badge ?>
+                        <?php endif; ?>
+                        <div class="listing-card__meta">
+                            <?php if (!empty($listing['species'])): ?>
+                                <span>Art: <?= htmlspecialchars($listing['species']) ?></span>
+                            <?php endif; ?>
+                            <?php if (!empty($listing['genetics'])): ?>
+                                <span>Genetik: <?= htmlspecialchars($listing['genetics']) ?></span>
+                            <?php endif; ?>
+                            <?php if (!empty($listing['price'])): ?>
+                                <span>Preis: <?= htmlspecialchars($listing['price']) ?></span>
+                            <?php endif; ?>
+                        </div>
+                        <?php if (!empty($listing['description'])): ?>
+                            <div class="rich-text-content">
+                                <?= render_rich_text($listing['description']) ?>
+                            </div>
+                        <?php endif; ?>
+                        <?php if (!empty($settings['contact_email'])): ?>
+                            <div class="listing-card__cta">
+                                <a class="button button--outline" href="mailto:<?= htmlspecialchars($settings['contact_email']) ?>?subject=Anfrage%20<?= urlencode($listing['title']) ?>">Direkt anfragen</a>
+                            </div>
+                        <?php endif; ?>
+                    </article>
+                <?php endforeach; ?>
+            </div>
         <?php endif; ?>
     </div>
-    <div class="rich-text-content prose prose-invert mt-6 max-w-none text-slate-200">
-        <?= render_rich_text($settings['adoption_intro'] ?? '') ?>
-    </div>
-    <div class="mt-10 grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
-        <?php foreach ($listings as $listing): ?>
-            <article class="flex h-full flex-col rounded-3xl border border-white/5 bg-night-900/70 p-6 shadow-lg shadow-black/40 transition hover:border-brand-400/60 hover:shadow-glow">
-                <?php if (!empty($listing['image_path'])): ?>
-                    <img src="<?= BASE_URL . '/' . htmlspecialchars($listing['image_path']) ?>" alt="<?= htmlspecialchars($listing['title']) ?>" class="mb-4 h-48 w-full rounded-2xl object-cover" loading="lazy">
-                <?php endif; ?>
-                <h3 class="text-xl font-semibold text-white"><?= htmlspecialchars($listing['title']) ?></h3>
-                <?php if (!empty($listing['species'])): ?>
-                    <p class="text-sm text-slate-300"><?= htmlspecialchars($listing['species']) ?></p>
-                <?php endif; ?>
-                <?php if (!empty($listing['genetics'])): ?>
-                    <p class="mt-2 rounded-xl border border-brand-400/40 bg-brand-500/10 px-3 py-2 text-sm text-brand-100">
-                        <span class="font-semibold uppercase tracking-wide">Genetik:</span>
-                        <?= htmlspecialchars($listing['genetics']) ?>
-                    </p>
-                <?php endif; ?>
-                <?php if (!empty($listing['price'])): ?>
-                    <p class="mt-2 text-sm text-slate-200"><strong>Preis:</strong> <?= htmlspecialchars($listing['price']) ?></p>
-                <?php endif; ?>
-                <?php if (!empty($listing['description'])): ?>
-                    <div class="rich-text-content prose prose-invert mt-3 max-w-none text-sm text-slate-200">
-                        <?= render_rich_text($listing['description']) ?>
-                    </div>
-                <?php endif; ?>
-                <?php if (!empty($settings['contact_email'])): ?>
-                    <a class="mt-4 inline-flex items-center justify-center rounded-full border border-brand-400/60 bg-brand-500/10 px-4 py-2 text-sm font-semibold text-brand-100 shadow-glow transition hover:border-brand-300 hover:bg-brand-500/20" href="mailto:<?= htmlspecialchars($settings['contact_email']) ?>?subject=Anfrage%20<?= urlencode($listing['title']) ?>">Direkt anfragen</a>
-                <?php endif; ?>
-            </article>
-        <?php endforeach; ?>
-    </div>
 </section>
+
 <?php if (!empty($latestNews)): ?>
-<section class="mx-auto mt-16 w-full max-w-7xl px-4 sm:px-6 lg:px-8">
-    <div class="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-            <h2 class="text-2xl font-semibold text-white sm:text-3xl">Neuigkeiten</h2>
-            <p class="text-sm text-slate-400">Aktuelle Meldungen aus Verein und Bestand</p>
+<section class="section">
+    <div class="section__inner">
+        <header class="section-header">
+            <h2 class="section-header__title">Neuigkeiten</h2>
+            <p class="section-header__description">Aktuelle Meldungen aus Organisation, Bestand und Veranstaltungen.</p>
+        </header>
+        <div class="card-grid">
+            <?php foreach ($latestNews as $post): ?>
+                <article class="card card--neutral">
+                    <h3 class="card__title"><?= htmlspecialchars($post['title']) ?></h3>
+                    <?php if (!empty($post['published_at'])): ?>
+                        <p class="card__subtitle">Veröffentlicht am <?= date('d.m.Y', strtotime($post['published_at'])) ?></p>
+                    <?php endif; ?>
+                    <?php if (!empty($post['excerpt'])): ?>
+                        <div class="rich-text-content">
+                            <p><?= nl2br(htmlspecialchars($post['excerpt'])) ?></p>
+                        </div>
+                    <?php endif; ?>
+                    <div class="card__cta">
+                        <a class="button button--outline" href="<?= BASE_URL ?>/index.php?route=news&amp;slug=<?= urlencode($post['slug']) ?>">Details ansehen</a>
+                    </div>
+                </article>
+            <?php endforeach; ?>
         </div>
-        <a class="inline-flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-sm font-semibold text-slate-100 transition hover:border-brand-400 hover:text-brand-100" href="<?= BASE_URL ?>/index.php?route=news">Alle Meldungen anzeigen</a>
-    </div>
-    <div class="mt-8 grid gap-6 md:grid-cols-3">
-        <?php foreach ($latestNews as $post): ?>
-            <article class="flex h-full flex-col rounded-3xl border border-white/5 bg-night-900/70 p-6 shadow-lg shadow-black/40 transition hover:border-brand-400/60 hover:shadow-glow">
-                <h3 class="text-xl font-semibold text-white"><?= htmlspecialchars($post['title']) ?></h3>
-                <?php if (!empty($post['published_at'])): ?>
-                    <p class="text-sm text-slate-400"><?= date('d.m.Y', strtotime($post['published_at'])) ?></p>
-                <?php endif; ?>
-                <?php if (!empty($post['excerpt'])): ?>
-                    <p class="mt-3 text-sm text-slate-200"><?= nl2br(htmlspecialchars($post['excerpt'])) ?></p>
-                <?php endif; ?>
-                <a class="mt-4 inline-flex items-center gap-2 rounded-full border border-brand-400/60 bg-brand-500/10 px-4 py-2 text-sm font-semibold text-brand-100 transition hover:border-brand-300 hover:bg-brand-500/20" href="<?= BASE_URL ?>/index.php?route=news&amp;slug=<?= urlencode($post['slug']) ?>">Details ansehen</a>
-            </article>
-        <?php endforeach; ?>
     </div>
 </section>
 <?php endif; ?>
 
 <?php if (!empty($careHighlights)): ?>
-<section class="mx-auto mt-16 w-full max-w-7xl px-4 sm:px-6 lg:px-8">
-    <div class="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-            <h2 class="text-2xl font-semibold text-white sm:text-3xl">Pflegewissen</h2>
-            <p class="text-sm text-slate-400">Vertiefende Artikel für verantwortungsvolle Haltung</p>
+<section class="section section--stripe">
+    <div class="section__inner">
+        <header class="section-header">
+            <h2 class="section-header__title">Pflegewissen</h2>
+            <p class="section-header__description">Vertiefende Artikel zu Habitat, Ernährung, UV-Bedarf und Rechtlichem.</p>
+        </header>
+        <div class="card-grid">
+            <?php foreach ($careHighlights as $article): ?>
+                <article class="card">
+                    <h3 class="card__title"><?= htmlspecialchars($article['title']) ?></h3>
+                    <?php if (!empty($article['reading_time'])): ?>
+                        <p class="card__subtitle">Lesezeit: <?= htmlspecialchars($article['reading_time']) ?> Minuten</p>
+                    <?php endif; ?>
+                    <?php if (!empty($article['excerpt'])): ?>
+                        <div class="rich-text-content">
+                            <p><?= htmlspecialchars($article['excerpt']) ?></p>
+                        </div>
+                    <?php endif; ?>
+                    <div class="card__cta">
+                        <a class="button button--outline" href="<?= BASE_URL ?>/index.php?route=care-article&amp;slug=<?= urlencode($article['slug']) ?>">Artikel lesen</a>
+                    </div>
+                </article>
+            <?php endforeach; ?>
         </div>
-        <a class="inline-flex items-center gap-2 rounded-full border border-brand-400/60 bg-brand-500/10 px-4 py-2 text-sm font-semibold text-brand-100 shadow-glow transition hover:border-brand-300 hover:bg-brand-500/20" href="<?= BASE_URL ?>/index.php?route=care-guide">Zur Wissenssammlung</a>
-    </div>
-    <div class="mt-8 grid gap-6 md:grid-cols-3">
-        <?php foreach ($careHighlights as $article): ?>
-            <article class="flex h-full flex-col rounded-3xl border border-white/5 bg-night-900/70 p-6 shadow-lg shadow-black/40 transition hover:border-brand-400/60 hover:shadow-glow">
-                <h3 class="text-xl font-semibold text-white"><?= htmlspecialchars($article['title']) ?></h3>
-                <?php if (!empty($article['summary'])): ?>
-                    <p class="mt-3 text-sm text-slate-200"><?= nl2br(htmlspecialchars($article['summary'])) ?></p>
-                <?php endif; ?>
-                <a class="mt-auto inline-flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-sm font-semibold text-slate-100 transition hover:border-brand-400 hover:text-brand-100" href="<?= BASE_URL ?>/index.php?route=care-article&amp;slug=<?= urlencode($article['slug']) ?>">Leitfaden öffnen</a>
-            </article>
-        <?php endforeach; ?>
     </div>
 </section>
 <?php endif; ?>
+
+<section class="section">
+    <div class="section__inner">
+        <header class="section-header">
+            <h2 class="section-header__title">Vertrauen &amp; Transparenz</h2>
+            <p class="section-header__description">Wir veröffentlichen alle relevanten Informationen zu Datenschutz, Recht und Ansprechpartnern.</p>
+        </header>
+        <div class="trust-grid">
+            <article class="trust-card">
+                <h3>Impressum &amp; Rechtliches</h3>
+                <p>Direkter Zugriff auf Impressum, Datenschutz, AGB und CITES-Hinweise für eine transparente Zusammenarbeit.</p>
+            </article>
+            <article class="trust-card">
+                <h3>Kontakt &amp; Beratung</h3>
+                <p>Individuelle Beratung zu Haltung, Übergabeoptionen und Genetik. Schreiben Sie uns jederzeit unter <?= htmlspecialchars($settings['contact_email'] ?? CONTACT_EMAIL) ?>.</p>
+            </article>
+            <article class="trust-card">
+                <h3>Partner &amp; Referenzen</h3>
+                <p>Wir arbeiten mit Tierärzt:innen, Reptilienparks und verantwortungsvollen Züchter:innen zusammen und veröffentlichen Referenzen transparent.</p>
+            </article>
+        </div>
+    </div>
+</section>
 
 <?php include __DIR__ . '/partials/footer.php'; ?>

--- a/public/views/home.php
+++ b/public/views/home.php
@@ -1,71 +1,158 @@
 <?php include __DIR__ . '/partials/header.php'; ?>
-<section class="hero">
-    <div>
-        <h1><?= htmlspecialchars($settings['site_title'] ?? APP_NAME) ?></h1>
-        <p><?= nl2br(htmlspecialchars($settings['hero_intro'] ?? '')) ?></p>
-    </div>
-    <div>
-        <span class="badge">Pflegeleitfaden</span>
-        <p>
-            Unsere Leitfäden decken Beleuchtung, Ernährung, Habitatgestaltung und Gesundheitsvorsorge für
-            <strong>Pogona vitticeps</strong> und <strong>Heterodon nasicus</strong> ab. Registrierte Benutzer erhalten
-            Zugriff auf individuelle Tierakten inklusive Genetik und Besonderheiten.
-        </p>
+<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
+    <div class="grid gap-10 rounded-3xl border border-white/5 bg-night-900/70 p-8 shadow-glow shadow-brand-600/20 lg:grid-cols-2">
+        <div class="space-y-6">
+            <h1 class="text-3xl font-semibold text-white sm:text-4xl lg:text-5xl"><?= htmlspecialchars($settings['site_title'] ?? APP_NAME) ?></h1>
+            <div class="rich-text-content prose prose-invert max-w-none">
+                <?= render_rich_text($settings['hero_intro'] ?? '') ?>
+            </div>
+        </div>
+        <div class="space-y-6">
+            <span class="inline-flex items-center gap-2 rounded-full border border-brand-400/60 bg-brand-500/10 px-4 py-2 text-sm font-semibold uppercase tracking-wide text-brand-100">Pflegeleitfaden</span>
+            <p class="text-base leading-relaxed text-slate-300">
+                Unsere Leitfäden decken Beleuchtung, Ernährung, Habitatgestaltung und Gesundheitsvorsorge für
+                <strong>Pogona vitticeps</strong> und <strong>Heterodon nasicus</strong> ab. Registrierte Benutzer erhalten
+                Zugriff auf individuelle Tierakten inklusive Genetik und Besonderheiten.
+            </p>
+            <div class="grid gap-3 sm:grid-cols-2">
+                <a href="<?= BASE_URL ?>/index.php?route=care-guide" class="flex items-center justify-between rounded-2xl border border-brand-400/50 bg-brand-500/10 px-4 py-3 text-sm font-semibold text-brand-100 shadow-glow transition hover:border-brand-300 hover:bg-brand-500/20">Pflegewissen entdecken <span aria-hidden="true">→</span></a>
+                <a href="<?= BASE_URL ?>/index.php?route=genetics" class="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-semibold text-slate-100 transition hover:border-brand-300 hover:text-brand-100">Genetik-Rechner starten <span aria-hidden="true">→</span></a>
+            </div>
+        </div>
     </div>
 </section>
 
 <?php if (!empty($animals)): ?>
-<section style="margin-top:3rem;">
-    <h2>Unsere Highlights</h2>
-    <div class="grid cards">
+<section class="mx-auto mt-16 w-full max-w-7xl px-4 sm:px-6 lg:px-8">
+    <div class="flex items-center justify-between">
+        <h2 class="text-2xl font-semibold text-white sm:text-3xl">Unsere Highlights</h2>
+        <span class="text-sm text-slate-400">Ausgewählte Tiere aus dem Bestand</span>
+    </div>
+    <div class="mt-8 grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
         <?php foreach ($animals as $animal): ?>
-            <article class="card">
+            <article class="group flex h-full flex-col rounded-3xl border border-white/5 bg-night-900/70 shadow-xl shadow-black/40 transition hover:border-brand-400/60 hover:shadow-glow">
                 <?php if (!empty($animal['image_path'])): ?>
-                    <img src="<?= BASE_URL . '/' . htmlspecialchars($animal['image_path']) ?>" alt="<?= htmlspecialchars($animal['name']) ?>">
+                    <img src="<?= BASE_URL . '/' . htmlspecialchars($animal['image_path']) ?>" alt="<?= htmlspecialchars($animal['name']) ?>" class="h-52 w-full rounded-t-3xl object-cover" loading="lazy">
                 <?php endif; ?>
-                <h3><?= htmlspecialchars($animal['name']) ?></h3>
-                <p><?= htmlspecialchars($animal['species']) ?></p>
-                <?php if (!empty($animal['genetics'])): ?>
-                    <span class="badge">Genetik</span>
-                    <p><?= htmlspecialchars($animal['genetics']) ?></p>
-                <?php endif; ?>
-                <?php if (!empty($animal['special_notes'])): ?>
-                    <p><?= nl2br(htmlspecialchars($animal['special_notes'])) ?></p>
-                <?php endif; ?>
+                <div class="flex flex-1 flex-col gap-3 p-6">
+                    <h3 class="text-xl font-semibold text-white">
+                        <?= htmlspecialchars($animal['name']) ?>
+                        <?php if (!empty($animal['is_piebald'])): ?>
+                            <span class="ml-2 inline-flex items-center justify-center rounded-full border border-brand-400 bg-brand-500/20 px-2 py-0.5 text-xs font-semibold uppercase tracking-wider text-brand-100" title="Geschecktes Tier" aria-label="Geschecktes Tier">Gescheckt</span>
+                        <?php endif; ?>
+                    </h3>
+                    <p class="text-sm text-slate-300"><?= htmlspecialchars($animal['species']) ?></p>
+                    <?php if (!empty($animal['genetics'])): ?>
+                        <div class="rounded-2xl border border-brand-400/30 bg-brand-500/5 px-3 py-2 text-sm text-brand-100">
+                            <span class="font-semibold uppercase tracking-wide">Genetik:</span>
+                            <?= htmlspecialchars($animal['genetics']) ?>
+                        </div>
+                    <?php endif; ?>
+                    <?php if (!empty($animal['special_notes'])): ?>
+                        <div class="rich-text-content prose prose-invert max-w-none text-sm text-slate-200">
+                            <?= render_rich_text($animal['special_notes']) ?>
+                        </div>
+                    <?php endif; ?>
+                </div>
             </article>
         <?php endforeach; ?>
     </div>
 </section>
 <?php endif; ?>
 
-<section style="margin-top:3rem;">
-    <h2>Tiervermittlung</h2>
-    <p><?= nl2br(htmlspecialchars($settings['adoption_intro'] ?? '')) ?></p>
-    <div class="grid cards">
+<section class="mx-auto mt-16 w-full max-w-7xl px-4 sm:px-6 lg:px-8">
+    <div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+            <h2 class="text-2xl font-semibold text-white sm:text-3xl">Tiervermittlung</h2>
+            <p class="text-sm text-slate-400">Aktuelle Vermittlungstiere und Kontakte</p>
+        </div>
+        <?php if (!empty($settings['contact_email'])): ?>
+            <a href="mailto:<?= htmlspecialchars($settings['contact_email']) ?>" class="inline-flex items-center gap-2 rounded-full border border-brand-400/60 bg-brand-500/10 px-4 py-2 text-sm font-semibold text-brand-100 shadow-glow transition hover:border-brand-300 hover:bg-brand-500/20">
+                Kontakt aufnehmen
+            </a>
+        <?php endif; ?>
+    </div>
+    <div class="rich-text-content prose prose-invert mt-6 max-w-none text-slate-200">
+        <?= render_rich_text($settings['adoption_intro'] ?? '') ?>
+    </div>
+    <div class="mt-10 grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
         <?php foreach ($listings as $listing): ?>
-            <article class="card">
+            <article class="flex h-full flex-col rounded-3xl border border-white/5 bg-night-900/70 p-6 shadow-lg shadow-black/40 transition hover:border-brand-400/60 hover:shadow-glow">
                 <?php if (!empty($listing['image_path'])): ?>
-                    <img src="<?= BASE_URL . '/' . htmlspecialchars($listing['image_path']) ?>" alt="<?= htmlspecialchars($listing['title']) ?>">
+                    <img src="<?= BASE_URL . '/' . htmlspecialchars($listing['image_path']) ?>" alt="<?= htmlspecialchars($listing['title']) ?>" class="mb-4 h-48 w-full rounded-2xl object-cover" loading="lazy">
                 <?php endif; ?>
-                <h3><?= htmlspecialchars($listing['title']) ?></h3>
+                <h3 class="text-xl font-semibold text-white"><?= htmlspecialchars($listing['title']) ?></h3>
                 <?php if (!empty($listing['species'])): ?>
-                    <p><?= htmlspecialchars($listing['species']) ?></p>
+                    <p class="text-sm text-slate-300"><?= htmlspecialchars($listing['species']) ?></p>
                 <?php endif; ?>
                 <?php if (!empty($listing['genetics'])): ?>
-                    <span class="badge">Genetik</span>
-                    <p><?= htmlspecialchars($listing['genetics']) ?></p>
+                    <p class="mt-2 rounded-xl border border-brand-400/40 bg-brand-500/10 px-3 py-2 text-sm text-brand-100">
+                        <span class="font-semibold uppercase tracking-wide">Genetik:</span>
+                        <?= htmlspecialchars($listing['genetics']) ?>
+                    </p>
                 <?php endif; ?>
                 <?php if (!empty($listing['price'])): ?>
-                    <p><strong>Preis:</strong> <?= htmlspecialchars($listing['price']) ?></p>
+                    <p class="mt-2 text-sm text-slate-200"><strong>Preis:</strong> <?= htmlspecialchars($listing['price']) ?></p>
                 <?php endif; ?>
                 <?php if (!empty($listing['description'])): ?>
-                    <p><?= nl2br(htmlspecialchars($listing['description'])) ?></p>
+                    <div class="rich-text-content prose prose-invert mt-3 max-w-none text-sm text-slate-200">
+                        <?= render_rich_text($listing['description']) ?>
+                    </div>
                 <?php endif; ?>
                 <?php if (!empty($settings['contact_email'])): ?>
-                    <a class="btn" href="mailto:<?= htmlspecialchars($settings['contact_email']) ?>?subject=Anfrage%20<?= urlencode($listing['title']) ?>">Direkt anfragen</a>
+                    <a class="mt-4 inline-flex items-center justify-center rounded-full border border-brand-400/60 bg-brand-500/10 px-4 py-2 text-sm font-semibold text-brand-100 shadow-glow transition hover:border-brand-300 hover:bg-brand-500/20" href="mailto:<?= htmlspecialchars($settings['contact_email']) ?>?subject=Anfrage%20<?= urlencode($listing['title']) ?>">Direkt anfragen</a>
                 <?php endif; ?>
             </article>
         <?php endforeach; ?>
     </div>
 </section>
+<?php if (!empty($latestNews)): ?>
+<section class="mx-auto mt-16 w-full max-w-7xl px-4 sm:px-6 lg:px-8">
+    <div class="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+            <h2 class="text-2xl font-semibold text-white sm:text-3xl">Neuigkeiten</h2>
+            <p class="text-sm text-slate-400">Aktuelle Meldungen aus Verein und Bestand</p>
+        </div>
+        <a class="inline-flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-sm font-semibold text-slate-100 transition hover:border-brand-400 hover:text-brand-100" href="<?= BASE_URL ?>/index.php?route=news">Alle Meldungen anzeigen</a>
+    </div>
+    <div class="mt-8 grid gap-6 md:grid-cols-3">
+        <?php foreach ($latestNews as $post): ?>
+            <article class="flex h-full flex-col rounded-3xl border border-white/5 bg-night-900/70 p-6 shadow-lg shadow-black/40 transition hover:border-brand-400/60 hover:shadow-glow">
+                <h3 class="text-xl font-semibold text-white"><?= htmlspecialchars($post['title']) ?></h3>
+                <?php if (!empty($post['published_at'])): ?>
+                    <p class="text-sm text-slate-400"><?= date('d.m.Y', strtotime($post['published_at'])) ?></p>
+                <?php endif; ?>
+                <?php if (!empty($post['excerpt'])): ?>
+                    <p class="mt-3 text-sm text-slate-200"><?= nl2br(htmlspecialchars($post['excerpt'])) ?></p>
+                <?php endif; ?>
+                <a class="mt-4 inline-flex items-center gap-2 rounded-full border border-brand-400/60 bg-brand-500/10 px-4 py-2 text-sm font-semibold text-brand-100 transition hover:border-brand-300 hover:bg-brand-500/20" href="<?= BASE_URL ?>/index.php?route=news&amp;slug=<?= urlencode($post['slug']) ?>">Details ansehen</a>
+            </article>
+        <?php endforeach; ?>
+    </div>
+</section>
+<?php endif; ?>
+
+<?php if (!empty($careHighlights)): ?>
+<section class="mx-auto mt-16 w-full max-w-7xl px-4 sm:px-6 lg:px-8">
+    <div class="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+            <h2 class="text-2xl font-semibold text-white sm:text-3xl">Pflegewissen</h2>
+            <p class="text-sm text-slate-400">Vertiefende Artikel für verantwortungsvolle Haltung</p>
+        </div>
+        <a class="inline-flex items-center gap-2 rounded-full border border-brand-400/60 bg-brand-500/10 px-4 py-2 text-sm font-semibold text-brand-100 shadow-glow transition hover:border-brand-300 hover:bg-brand-500/20" href="<?= BASE_URL ?>/index.php?route=care-guide">Zur Wissenssammlung</a>
+    </div>
+    <div class="mt-8 grid gap-6 md:grid-cols-3">
+        <?php foreach ($careHighlights as $article): ?>
+            <article class="flex h-full flex-col rounded-3xl border border-white/5 bg-night-900/70 p-6 shadow-lg shadow-black/40 transition hover:border-brand-400/60 hover:shadow-glow">
+                <h3 class="text-xl font-semibold text-white"><?= htmlspecialchars($article['title']) ?></h3>
+                <?php if (!empty($article['summary'])): ?>
+                    <p class="mt-3 text-sm text-slate-200"><?= nl2br(htmlspecialchars($article['summary'])) ?></p>
+                <?php endif; ?>
+                <a class="mt-auto inline-flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-sm font-semibold text-slate-100 transition hover:border-brand-400 hover:text-brand-100" href="<?= BASE_URL ?>/index.php?route=care-article&amp;slug=<?= urlencode($article['slug']) ?>">Leitfaden öffnen</a>
+            </article>
+        <?php endforeach; ?>
+    </div>
+</section>
+<?php endif; ?>
+
 <?php include __DIR__ . '/partials/footer.php'; ?>

--- a/public/views/news/index.php
+++ b/public/views/news/index.php
@@ -1,23 +1,28 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
-<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
-    <header class="max-w-3xl">
-        <h1 class="text-3xl font-semibold text-white sm:text-4xl">Neuigkeiten</h1>
-        <p class="mt-2 text-sm text-slate-300">Aktuelle Updates aus dem FeroxZ Center.</p>
-    </header>
-    <div class="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-        <?php foreach ($newsPosts as $post): ?>
-            <article class="flex h-full flex-col rounded-3xl border border-white/5 bg-night-900/70 p-6 shadow-lg shadow-black/30 transition hover:border-brand-400/60 hover:shadow-glow">
-                <h2 class="text-xl font-semibold text-white"><?= htmlspecialchars($post['title']) ?></h2>
-                <?php if (!empty($post['published_at'])): ?>
-                    <p class="text-xs uppercase tracking-wide text-slate-400">Veröffentlicht am <?= date('d.m.Y H:i', strtotime($post['published_at'])) ?></p>
-                <?php endif; ?>
-                <?php if (!empty($post['excerpt'])): ?>
-                    <p class="mt-3 text-sm text-slate-200"><?= nl2br(htmlspecialchars($post['excerpt'])) ?></p>
-                <?php endif; ?>
-                <a class="mt-auto inline-flex items-center gap-2 rounded-full border border-brand-400/60 bg-brand-500/10 px-4 py-2 text-sm font-semibold text-brand-100 transition hover:border-brand-300 hover:bg-brand-500/20" href="<?= BASE_URL ?>/index.php?route=news&amp;slug=<?= urlencode($post['slug']) ?>">Weiterlesen</a>
-            </article>
-        <?php endforeach; ?>
+<section class="section">
+    <div class="section__inner">
+        <header class="section-header">
+            <h1 class="section-header__title">Neuigkeiten</h1>
+            <p class="section-header__description">Aktuelle Meldungen, Events und Hintergrundberichte aus dem FeroxZ Reptile Center.</p>
+        </header>
+        <div class="card-grid">
+            <?php foreach ($posts as $post): ?>
+                <article class="card card--neutral">
+                    <h2 class="card__title"><?= htmlspecialchars($post['title']) ?></h2>
+                    <?php if (!empty($post['published_at'])): ?>
+                        <p class="card__subtitle">Veröffentlicht am <?= date('d.m.Y', strtotime($post['published_at'])) ?></p>
+                    <?php endif; ?>
+                    <?php if (!empty($post['excerpt'])): ?>
+                        <div class="rich-text-content">
+                            <p><?= nl2br(htmlspecialchars($post['excerpt'])) ?></p>
+                        </div>
+                    <?php endif; ?>
+                    <div class="card__cta">
+                        <a class="button button--outline" href="<?= BASE_URL ?>/index.php?route=news&amp;slug=<?= urlencode($post['slug']) ?>">Weiterlesen</a>
+                    </div>
+                </article>
+            <?php endforeach; ?>
+        </div>
     </div>
 </section>
 <?php include __DIR__ . '/../partials/footer.php'; ?>
-

--- a/public/views/news/index.php
+++ b/public/views/news/index.php
@@ -1,0 +1,23 @@
+<?php include __DIR__ . '/../partials/header.php'; ?>
+<section class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
+    <header class="max-w-3xl">
+        <h1 class="text-3xl font-semibold text-white sm:text-4xl">Neuigkeiten</h1>
+        <p class="mt-2 text-sm text-slate-300">Aktuelle Updates aus dem FeroxZ Center.</p>
+    </header>
+    <div class="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+        <?php foreach ($newsPosts as $post): ?>
+            <article class="flex h-full flex-col rounded-3xl border border-white/5 bg-night-900/70 p-6 shadow-lg shadow-black/30 transition hover:border-brand-400/60 hover:shadow-glow">
+                <h2 class="text-xl font-semibold text-white"><?= htmlspecialchars($post['title']) ?></h2>
+                <?php if (!empty($post['published_at'])): ?>
+                    <p class="text-xs uppercase tracking-wide text-slate-400">Veröffentlicht am <?= date('d.m.Y H:i', strtotime($post['published_at'])) ?></p>
+                <?php endif; ?>
+                <?php if (!empty($post['excerpt'])): ?>
+                    <p class="mt-3 text-sm text-slate-200"><?= nl2br(htmlspecialchars($post['excerpt'])) ?></p>
+                <?php endif; ?>
+                <a class="mt-auto inline-flex items-center gap-2 rounded-full border border-brand-400/60 bg-brand-500/10 px-4 py-2 text-sm font-semibold text-brand-100 transition hover:border-brand-300 hover:bg-brand-500/20" href="<?= BASE_URL ?>/index.php?route=news&amp;slug=<?= urlencode($post['slug']) ?>">Weiterlesen</a>
+            </article>
+        <?php endforeach; ?>
+    </div>
+</section>
+<?php include __DIR__ . '/../partials/footer.php'; ?>
+

--- a/public/views/news/show.php
+++ b/public/views/news/show.php
@@ -1,17 +1,31 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
-<section class="mx-auto w-full max-w-3xl px-4 sm:px-6 lg:px-8">
-    <article class="rounded-3xl border border-white/5 bg-night-900/70 p-8 shadow-lg shadow-black/30">
-        <h1 class="text-3xl font-semibold text-white sm:text-4xl"><?= htmlspecialchars($post['title']) ?></h1>
-        <?php if (!empty($post['published_at'])): ?>
-            <p class="mt-2 text-xs uppercase tracking-wide text-slate-400">Veröffentlicht am <?= date('d.m.Y H:i', strtotime($post['published_at'])) ?></p>
+<section class="section">
+    <div class="section__inner">
+        <?php if (!empty($pageMeta['breadcrumbs'])): ?>
+            <nav class="breadcrumb" aria-label="Brotkrumen">
+                <?php foreach ($pageMeta['breadcrumbs'] as $crumb): ?>
+                    <a href="<?= htmlspecialchars($crumb['url']) ?>"><?= htmlspecialchars($crumb['name']) ?></a>
+                    <span aria-hidden="true">/</span>
+                <?php endforeach; ?>
+                <span><?= htmlspecialchars($post['title']) ?></span>
+            </nav>
         <?php endif; ?>
-        <?php if (!empty($post['excerpt'])): ?>
-            <p class="mt-4 text-sm italic text-slate-200"><?= nl2br(htmlspecialchars($post['excerpt'])) ?></p>
-        <?php endif; ?>
-        <div class="rich-text-content prose prose-invert mt-6 max-w-none text-slate-100">
-            <?= render_rich_text($post['content']) ?>
-        </div>
-    </article>
+        <article class="article-shell">
+            <header>
+                <time datetime="<?= htmlspecialchars(date('Y-m-d', strtotime($post['published_at'] ?? 'now'))) ?>">Veröffentlicht am <?= date('d.m.Y', strtotime($post['published_at'] ?? 'now')) ?></time>
+                <h1><?= htmlspecialchars($post['title']) ?></h1>
+            </header>
+            <?php if (!empty($post['hero_image'])): ?>
+                <figure>
+                    <?= render_responsive_picture($post['hero_image'], $post['title'], [
+                        'sizes' => '(max-width: 768px) 100vw, 960px',
+                    ]) ?>
+                </figure>
+            <?php endif; ?>
+            <div class="content-prose">
+                <?= render_rich_text($post['content']) ?>
+            </div>
+        </article>
+    </div>
 </section>
 <?php include __DIR__ . '/../partials/footer.php'; ?>
-

--- a/public/views/news/show.php
+++ b/public/views/news/show.php
@@ -1,0 +1,17 @@
+<?php include __DIR__ . '/../partials/header.php'; ?>
+<section class="mx-auto w-full max-w-3xl px-4 sm:px-6 lg:px-8">
+    <article class="rounded-3xl border border-white/5 bg-night-900/70 p-8 shadow-lg shadow-black/30">
+        <h1 class="text-3xl font-semibold text-white sm:text-4xl"><?= htmlspecialchars($post['title']) ?></h1>
+        <?php if (!empty($post['published_at'])): ?>
+            <p class="mt-2 text-xs uppercase tracking-wide text-slate-400">Veröffentlicht am <?= date('d.m.Y H:i', strtotime($post['published_at'])) ?></p>
+        <?php endif; ?>
+        <?php if (!empty($post['excerpt'])): ?>
+            <p class="mt-4 text-sm italic text-slate-200"><?= nl2br(htmlspecialchars($post['excerpt'])) ?></p>
+        <?php endif; ?>
+        <div class="rich-text-content prose prose-invert mt-6 max-w-none text-slate-100">
+            <?= render_rich_text($post['content']) ?>
+        </div>
+    </article>
+</section>
+<?php include __DIR__ . '/../partials/footer.php'; ?>
+

--- a/public/views/pages/show.php
+++ b/public/views/pages/show.php
@@ -1,0 +1,11 @@
+<?php include __DIR__ . '/../partials/header.php'; ?>
+<section class="mx-auto w-full max-w-4xl px-4 sm:px-6 lg:px-8">
+    <article class="rounded-3xl border border-white/5 bg-night-900/70 p-8 shadow-lg shadow-black/30">
+        <h1 class="text-3xl font-semibold text-white sm:text-4xl"><?= htmlspecialchars($page['title']) ?></h1>
+        <div class="rich-text-content prose prose-invert mt-6 max-w-none text-slate-100">
+            <?= render_rich_text($page['content']) ?>
+        </div>
+    </article>
+</section>
+<?php include __DIR__ . '/../partials/footer.php'; ?>
+

--- a/public/views/pages/show.php
+++ b/public/views/pages/show.php
@@ -1,11 +1,14 @@
 <?php include __DIR__ . '/../partials/header.php'; ?>
-<section class="mx-auto w-full max-w-4xl px-4 sm:px-6 lg:px-8">
-    <article class="rounded-3xl border border-white/5 bg-night-900/70 p-8 shadow-lg shadow-black/30">
-        <h1 class="text-3xl font-semibold text-white sm:text-4xl"><?= htmlspecialchars($page['title']) ?></h1>
-        <div class="rich-text-content prose prose-invert mt-6 max-w-none text-slate-100">
-            <?= render_rich_text($page['content']) ?>
-        </div>
-    </article>
+<section class="section">
+    <div class="section__inner">
+        <article class="article-shell">
+            <header>
+                <h1><?= htmlspecialchars($page['title']) ?></h1>
+            </header>
+            <div class="content-prose">
+                <?= render_rich_text($page['content']) ?>
+            </div>
+        </article>
+    </div>
 </section>
 <?php include __DIR__ . '/../partials/footer.php'; ?>
-

--- a/public/views/partials/footer.php
+++ b/public/views/partials/footer.php
@@ -1,9 +1,61 @@
     </div>
 </main>
-<footer class="footer">
-    <div class="wrapper">
-        <?= nl2br(htmlspecialchars($settings['footer_text'] ?? '')) ?>
+<footer class="border-t border-white/5 bg-night-900/80 py-10">
+    <div class="mx-auto flex w-full max-w-7xl flex-col gap-4 px-4 text-sm text-slate-400 sm:flex-row sm:items-center sm:justify-between sm:px-6 lg:px-8">
+        <div class="prose prose-invert max-w-none text-slate-300">
+            <?= nl2br(htmlspecialchars($settings['footer_text'] ?? '')) ?>
+        </div>
+        <div class="flex items-center gap-3 text-xs text-slate-500">
+            <span>© <?= date('Y') ?> <?= htmlspecialchars($settings['site_title'] ?? APP_NAME) ?></span>
+            <span aria-hidden="true">•</span>
+            <span>Alle Rechte vorbehalten.</span>
+        </div>
     </div>
 </footer>
+<script>
+    (function () {
+        const mobileToggle = document.querySelector('[data-mobile-nav-toggle]');
+        const mobilePanel = document.querySelector('[data-mobile-nav-panel]');
+        if (mobileToggle && mobilePanel) {
+            mobileToggle.addEventListener('click', () => {
+                mobilePanel.classList.toggle('hidden');
+                const expanded = mobileToggle.getAttribute('aria-expanded') === 'true';
+                mobileToggle.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+            });
+        }
+
+        document.querySelectorAll('[data-nav-group]').forEach((group) => {
+            const trigger = group.querySelector('[data-nav-trigger]');
+            const dropdown = group.querySelector('.nav-dropdown');
+            if (!trigger || !dropdown) {
+                return;
+            }
+            trigger.setAttribute('aria-haspopup', 'true');
+            trigger.setAttribute('aria-expanded', 'false');
+            trigger.addEventListener('click', (event) => {
+                event.preventDefault();
+                const isOpen = dropdown.classList.toggle('open');
+                trigger.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+            });
+            group.addEventListener('mouseleave', () => {
+                dropdown.classList.remove('open');
+                trigger.setAttribute('aria-expanded', 'false');
+            });
+            group.addEventListener('keyup', (event) => {
+                if (event.key === 'Escape') {
+                    dropdown.classList.remove('open');
+                    trigger.setAttribute('aria-expanded', 'false');
+                    trigger.focus();
+                }
+            });
+        });
+    })();
+</script>
+<?php if (($currentRoute ?? '') === 'genetics'): ?>
+    <script src="<?= asset('genetics.js') ?>"></script>
+<?php endif; ?>
+<?php if (isset($currentRoute) && str_starts_with($currentRoute, 'admin/')): ?>
+    <script src="<?= asset('admin.js') ?>"></script>
+<?php endif; ?>
 </body>
 </html>

--- a/public/views/partials/footer.php
+++ b/public/views/partials/footer.php
@@ -1,11 +1,10 @@
-    </div>
 </main>
-<footer class="border-t border-white/5 bg-night-900/80 py-10">
-    <div class="mx-auto flex w-full max-w-7xl flex-col gap-4 px-4 text-sm text-slate-400 sm:flex-row sm:items-center sm:justify-between sm:px-6 lg:px-8">
-        <div class="prose prose-invert max-w-none text-slate-300">
-            <?= nl2br(htmlspecialchars($settings['footer_text'] ?? '')) ?>
+<footer class="site-footer">
+    <div class="site-footer__inner">
+        <div class="content-prose">
+            <?= nl2br(htmlspecialchars($settings['footer_text'] ?? 'FeroxZ Reptile Center – verantwortungsvolle Haltung und Genetikberatung für Bartagamen.')) ?>
         </div>
-        <div class="flex items-center gap-3 text-xs text-slate-500">
+        <div class="site-footer__meta">
             <span>© <?= date('Y') ?> <?= htmlspecialchars($settings['site_title'] ?? APP_NAME) ?></span>
             <span aria-hidden="true">•</span>
             <span>Alle Rechte vorbehalten.</span>
@@ -14,36 +13,50 @@
 </footer>
 <script>
     (function () {
-        const mobileToggle = document.querySelector('[data-mobile-nav-toggle]');
-        const mobilePanel = document.querySelector('[data-mobile-nav-panel]');
-        if (mobileToggle && mobilePanel) {
-            mobileToggle.addEventListener('click', () => {
-                mobilePanel.classList.toggle('hidden');
-                const expanded = mobileToggle.getAttribute('aria-expanded') === 'true';
-                mobileToggle.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+        const nav = document.querySelector('[data-nav]');
+        const toggle = document.querySelector('[data-nav-toggle]');
+        const groups = document.querySelectorAll('[data-nav-group]');
+        if (toggle && nav) {
+            toggle.addEventListener('click', () => {
+                const isOpen = nav.getAttribute('data-open') === 'true';
+                nav.setAttribute('data-open', isOpen ? 'false' : 'true');
+                toggle.setAttribute('aria-expanded', isOpen ? 'false' : 'true');
+            });
+            nav.querySelectorAll('a').forEach((link) => {
+                link.addEventListener('click', () => {
+                    if (window.innerWidth <= 1080) {
+                        nav.setAttribute('data-open', 'false');
+                        toggle.setAttribute('aria-expanded', 'false');
+                    }
+                });
             });
         }
-
-        document.querySelectorAll('[data-nav-group]').forEach((group) => {
+        groups.forEach((group) => {
             const trigger = group.querySelector('[data-nav-trigger]');
-            const dropdown = group.querySelector('.nav-dropdown');
+            const dropdown = group.querySelector('.site-nav__dropdown');
             if (!trigger || !dropdown) {
                 return;
             }
-            trigger.setAttribute('aria-haspopup', 'true');
-            trigger.setAttribute('aria-expanded', 'false');
             trigger.addEventListener('click', (event) => {
                 event.preventDefault();
-                const isOpen = dropdown.classList.toggle('open');
-                trigger.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+                const isOpen = group.classList.contains('open');
+                document.querySelectorAll('.site-nav__group.open').forEach((openGroup) => {
+                    if (openGroup !== group) {
+                        openGroup.classList.remove('open');
+                        const openTrigger = openGroup.querySelector('[data-nav-trigger]');
+                        openTrigger?.setAttribute('aria-expanded', 'false');
+                    }
+                });
+                group.classList.toggle('open', !isOpen);
+                trigger.setAttribute('aria-expanded', !isOpen ? 'true' : 'false');
             });
             group.addEventListener('mouseleave', () => {
-                dropdown.classList.remove('open');
+                group.classList.remove('open');
                 trigger.setAttribute('aria-expanded', 'false');
             });
             group.addEventListener('keyup', (event) => {
                 if (event.key === 'Escape') {
-                    dropdown.classList.remove('open');
+                    group.classList.remove('open');
                     trigger.setAttribute('aria-expanded', 'false');
                     trigger.focus();
                 }
@@ -51,6 +64,42 @@
         });
     })();
 </script>
+<?php
+    $schemaBlocks = [
+        [
+            '@context' => 'https://schema.org',
+            '@type' => 'Organization',
+            'name' => ORG_NAME,
+            'url' => 'https://' . SITE_DOMAIN,
+            'logo' => ORG_LOGO_URL,
+            'email' => CONTACT_EMAIL,
+            'sameAs' => ORG_SAME_AS,
+        ],
+    ];
+
+    if (!empty($pageMeta['breadcrumbs'])) {
+        $schemaBlocks[] = [
+            '@context' => 'https://schema.org',
+            '@type' => 'BreadcrumbList',
+            'itemListElement' => array_map(static function ($crumb) {
+                return [
+                    '@type' => 'ListItem',
+                    'position' => $crumb['position'],
+                    'name' => $crumb['name'],
+                    'item' => $crumb['url'],
+                ];
+            }, $pageMeta['breadcrumbs']),
+        ];
+    }
+
+    if (!empty($pageMeta['schema'])) {
+        foreach ($pageMeta['schema'] as $schemaBlock) {
+            $schemaBlocks[] = $schemaBlock;
+        }
+    }
+
+    echo render_structured_data($schemaBlocks);
+?>
 <?php if (($currentRoute ?? '') === 'genetics'): ?>
     <script src="<?= asset('genetics.js') ?>"></script>
 <?php endif; ?>

--- a/public/views/partials/header.php
+++ b/public/views/partials/header.php
@@ -4,34 +4,181 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= htmlspecialchars($settings['site_title'] ?? APP_NAME) ?></title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        night: {
+                            900: '#020617',
+                            800: '#0f172a',
+                            700: '#1e293b',
+                        },
+                        brand: {
+                            400: '#22d3ee',
+                            500: '#06b6d4',
+                            600: '#0891b2',
+                        },
+                    },
+                    boxShadow: {
+                        glow: '0 25px 65px rgba(15, 118, 110, 0.35)',
+                    },
+                    fontFamily: {
+                        sans: ['Inter', 'system-ui', 'ui-sans-serif', 'Segoe UI', 'sans-serif'],
+                    },
+                }
+            }
+        };
+    </script>
     <link rel="stylesheet" href="<?= asset('style.css') ?>">
 </head>
-<body>
-<header>
-    <div class="wrapper">
-        <nav class="navbar">
-            <div>
-                <strong><?= htmlspecialchars($settings['site_title'] ?? APP_NAME) ?></strong>
-                <div style="font-size:0.85rem;color:var(--text-muted);margin-top:0.25rem;">
-                    <?= htmlspecialchars($settings['site_tagline'] ?? '') ?>
+<body class="min-h-screen bg-gradient-to-br from-night-900 via-night-800 to-slate-900 font-sans text-slate-100">
+<header class="sticky top-0 z-50 border-b border-white/5 bg-night-900/80 backdrop-blur">
+    <div class="mx-auto flex w-full max-w-7xl items-center justify-between px-4 py-4 sm:px-6 lg:px-8">
+        <a href="<?= BASE_URL ?>/index.php" class="flex items-center gap-3">
+            <span class="flex h-10 w-10 items-center justify-center rounded-full bg-brand-500/20 text-lg font-semibold text-brand-400 ring-2 ring-brand-500/30">
+                <?= strtoupper(substr($settings['site_title'] ?? APP_NAME, 0, 2)) ?>
+            </span>
+            <span>
+                <span class="block text-lg font-semibold tracking-wide text-slate-100"><?= htmlspecialchars($settings['site_title'] ?? APP_NAME) ?></span>
+                <span class="block text-sm text-slate-400"><?= htmlspecialchars($settings['site_tagline'] ?? '') ?></span>
+            </span>
+        </a>
+        <div class="flex items-center gap-3 lg:hidden">
+            <button type="button" class="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-white/10 text-slate-200 shadow-sm shadow-brand-600/20 transition hover:border-brand-400 hover:text-brand-300" data-mobile-nav-toggle>
+                <span class="sr-only">Navigation umschalten</span>
+                <svg class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="1.6" viewBox="0 0 24 24" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+                </svg>
+            </button>
+        </div>
+        <?php
+            $navLinkBase = 'inline-flex items-center gap-1 rounded-full border border-white/10 px-4 py-2 text-slate-200 transition hover:border-brand-400 hover:bg-brand-500/10 hover:text-brand-100';
+            $navLinkActive = 'inline-flex items-center gap-1 rounded-full border border-brand-400 bg-brand-500/90 px-4 py-2 text-night-900 shadow-glow';
+            $dropdownLinkBase = 'block rounded-lg px-3 py-2 text-left text-slate-200 transition hover:bg-white/5 hover:text-brand-200';
+            $dropdownLinkActive = 'block rounded-lg px-3 py-2 text-left bg-brand-500/20 text-brand-100 shadow-inner shadow-brand-600/20';
+            $mobileLinkBase = 'block rounded-xl border border-white/5 px-4 py-2 text-slate-200 transition hover:border-brand-400 hover:bg-brand-500/10 hover:text-brand-100';
+            $mobileLinkActive = 'block rounded-xl border border-brand-400 bg-brand-500/20 px-4 py-2 text-brand-50 shadow-glow';
+            $mobileSubBase = 'block rounded-lg px-3 py-2 text-slate-300 hover:bg-brand-500/10 hover:text-brand-100';
+            $mobileSubActive = 'block rounded-lg px-3 py-2 text-brand-100 bg-brand-500/20';
+        ?>
+        <nav class="hidden items-center gap-2 text-sm font-medium lg:flex" data-desktop-nav>
+            <a href="<?= BASE_URL ?>/index.php" class="<?= ($currentRoute === 'home') ? $navLinkActive : $navLinkBase ?>">Start</a>
+            <a href="<?= BASE_URL ?>/index.php?route=animals" class="<?= ($currentRoute === 'animals') ? $navLinkActive : $navLinkBase ?>">Tierübersicht</a>
+            <a href="<?= BASE_URL ?>/index.php?route=news" class="<?= ($currentRoute === 'news') ? $navLinkActive : $navLinkBase ?>">Neuigkeiten</a>
+            <div class="relative" data-nav-group>
+                <?php $isCareActive = ($currentRoute === 'care-guide' || $currentRoute === 'care-article'); ?>
+                <button type="button" class="<?= $isCareActive ? $navLinkActive : $navLinkBase ?>" data-nav-trigger>
+                    Pflegeleitfaden
+                    <svg class="h-4 w-4 transition" data-chevron fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M6 9l6 6 6-6" />
+                    </svg>
+                </button>
+                <div class="nav-dropdown">
+                    <a href="<?= BASE_URL ?>/index.php?route=care-guide" class="<?= ($currentRoute === 'care-guide') ? $dropdownLinkActive : $dropdownLinkBase ?>">Übersicht</a>
+                    <?php foreach (($navCareArticles ?? []) as $careNav): ?>
+                        <a href="<?= BASE_URL ?>/index.php?route=care-article&amp;slug=<?= urlencode($careNav['slug']) ?>" class="<?= ($currentRoute === 'care-article' && ($activeCareSlug ?? '') === $careNav['slug']) ? $dropdownLinkActive : $dropdownLinkBase ?>"><?= htmlspecialchars($careNav['title']) ?></a>
+                    <?php endforeach; ?>
                 </div>
             </div>
-            <div class="nav-links">
-                <a href="<?= BASE_URL ?>/index.php" class="<?= ($currentRoute === 'home') ? 'active' : '' ?>">Start</a>
-                <a href="<?= BASE_URL ?>/index.php?route=animals" class="<?= ($currentRoute === 'animals') ? 'active' : '' ?>">Tierübersicht</a>
-                <?php if (current_user()): ?>
-                    <a href="<?= BASE_URL ?>/index.php?route=my-animals" class="<?= ($currentRoute === 'my-animals') ? 'active' : '' ?>">Meine Tiere</a>
-                <?php endif; ?>
-                <a href="<?= BASE_URL ?>/index.php?route=adoption" class="<?= ($currentRoute === 'adoption') ? 'active' : '' ?>">Tierabgabe</a>
-                <?php if (current_user()): ?>
-                    <a href="<?= BASE_URL ?>/index.php?route=admin/dashboard" class="<?= str_starts_with($currentRoute, 'admin/') ? 'active' : '' ?>">Admin</a>
-                    <a href="<?= BASE_URL ?>/index.php?route=logout">Logout</a>
-                <?php else: ?>
-                    <a href="<?= BASE_URL ?>/index.php?route=login" class="<?= ($currentRoute === 'login') ? 'active' : '' ?>">Login</a>
-                <?php endif; ?>
-            </div>
+            <a href="<?= BASE_URL ?>/index.php?route=genetics" class="<?= ($currentRoute === 'genetics') ? $navLinkActive : $navLinkBase ?>">Genetik Rechner</a>
+            <?php foreach (($navPages ?? []) as $navPage): ?>
+                <?php
+                    $parentActive = ($currentRoute === 'page' && ($activePageSlug ?? '') === $navPage['slug']);
+                    $childActive = false;
+                    foreach ($navPage['children'] ?? [] as $childPage) {
+                        if ($currentRoute === 'page' && ($activePageSlug ?? '') === $childPage['slug']) {
+                            $childActive = true;
+                            break;
+                        }
+                    }
+                    $isActive = $parentActive || $childActive;
+                ?>
+                <div class="relative" data-nav-group>
+                    <a href="<?= BASE_URL ?>/index.php?route=page&amp;slug=<?= urlencode($navPage['slug']) ?>" class="<?= $isActive ? $navLinkActive : $navLinkBase ?>">
+                        <?= htmlspecialchars($navPage['title']) ?>
+                        <?php if (!empty($navPage['children'])): ?>
+                            <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M6 9l6 6 6-6" />
+                            </svg>
+                        <?php endif; ?>
+                    </a>
+                    <?php if (!empty($navPage['children'])): ?>
+                        <div class="nav-dropdown">
+                            <?php foreach ($navPage['children'] as $childPage): ?>
+                                <a href="<?= BASE_URL ?>/index.php?route=page&amp;slug=<?= urlencode($childPage['slug']) ?>" class="<?= ($currentRoute === 'page' && ($activePageSlug ?? '') === $childPage['slug']) ? $dropdownLinkActive : $dropdownLinkBase ?>"><?= htmlspecialchars($childPage['title']) ?></a>
+                            <?php endforeach; ?>
+                        </div>
+                    <?php endif; ?>
+                </div>
+            <?php endforeach; ?>
+            <a href="<?= BASE_URL ?>/index.php?route=adoption" class="<?= ($currentRoute === 'adoption') ? $navLinkActive : $navLinkBase ?>">Tierabgabe</a>
+            <?php if (current_user()): ?>
+                <a href="<?= BASE_URL ?>/index.php?route=my-animals" class="<?= ($currentRoute === 'my-animals') ? $navLinkActive : $navLinkBase ?>">Meine Tiere</a>
+                <a href="<?= BASE_URL ?>/index.php?route=breeding" class="<?= ($currentRoute === 'breeding') ? $navLinkActive : $navLinkBase ?>">Zuchtplanung</a>
+                <a href="<?= BASE_URL ?>/index.php?route=admin/dashboard" class="<?= str_starts_with($currentRoute, 'admin/') ? $navLinkActive : $navLinkBase ?>">Admin</a>
+                <a href="<?= BASE_URL ?>/index.php?route=logout" class="<?= $navLinkBase ?>">Logout</a>
+            <?php else: ?>
+                <a href="<?= BASE_URL ?>/index.php?route=login" class="<?= ($currentRoute === 'login') ? $navLinkActive : $navLinkBase ?>">Login</a>
+            <?php endif; ?>
+        </nav>
+    </div>
+    <div class="hidden lg:hidden" data-mobile-nav-panel>
+        <nav class="mx-4 mb-4 space-y-2 rounded-2xl border border-white/5 bg-night-900/95 p-4 text-sm shadow-lg shadow-brand-600/10">
+            <a href="<?= BASE_URL ?>/index.php" class="<?= ($currentRoute === 'home') ? $mobileLinkActive : $mobileLinkBase ?>">Start</a>
+            <a href="<?= BASE_URL ?>/index.php?route=animals" class="<?= ($currentRoute === 'animals') ? $mobileLinkActive : $mobileLinkBase ?>">Tierübersicht</a>
+            <a href="<?= BASE_URL ?>/index.php?route=news" class="<?= ($currentRoute === 'news') ? $mobileLinkActive : $mobileLinkBase ?>">Neuigkeiten</a>
+            <details class="group" <?= $isCareActive ? 'open' : '' ?>>
+                <summary class="<?= $mobileLinkBase ?> flex cursor-pointer list-none items-center justify-between">
+                    <span>Pflegeleitfaden</span>
+                    <svg class="h-4 w-4 transition group-open:rotate-180" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M6 9l6 6 6-6" /></svg>
+                </summary>
+                <div class="mt-2 space-y-1 pl-3 text-sm">
+                    <a href="<?= BASE_URL ?>/index.php?route=care-guide" class="<?= ($currentRoute === 'care-guide') ? $mobileSubActive : $mobileSubBase ?>">Übersicht</a>
+                    <?php foreach (($navCareArticles ?? []) as $careNav): ?>
+                        <a href="<?= BASE_URL ?>/index.php?route=care-article&amp;slug=<?= urlencode($careNav['slug']) ?>" class="<?= ($currentRoute === 'care-article' && ($activeCareSlug ?? '') === $careNav['slug']) ? $mobileSubActive : $mobileSubBase ?>"><?= htmlspecialchars($careNav['title']) ?></a>
+                    <?php endforeach; ?>
+                </div>
+            </details>
+            <a href="<?= BASE_URL ?>/index.php?route=genetics" class="<?= ($currentRoute === 'genetics') ? $mobileLinkActive : $mobileLinkBase ?>">Genetik Rechner</a>
+            <?php foreach (($navPages ?? []) as $navPage): ?>
+                <?php
+                    $parentActive = ($currentRoute === 'page' && ($activePageSlug ?? '') === $navPage['slug']);
+                    $childActive = false;
+                    foreach ($navPage['children'] ?? [] as $childPage) {
+                        if ($currentRoute === 'page' && ($activePageSlug ?? '') === $childPage['slug']) {
+                            $childActive = true;
+                            break;
+                        }
+                    }
+                ?>
+                <details class="group" <?= ($parentActive || $childActive) ? 'open' : '' ?>>
+                    <summary class="<?= $mobileLinkBase ?> flex cursor-pointer list-none items-center justify-between">
+                        <span><?= htmlspecialchars($navPage['title']) ?></span>
+                        <?php if (!empty($navPage['children'])): ?>
+                            <svg class="h-4 w-4 transition group-open:rotate-180" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M6 9l6 6 6-6" /></svg>
+                        <?php endif; ?>
+                    </summary>
+                    <?php if (!empty($navPage['children'])): ?>
+                        <div class="mt-2 space-y-1 pl-3 text-sm">
+                            <?php foreach ($navPage['children'] as $childPage): ?>
+                                <a href="<?= BASE_URL ?>/index.php?route=page&amp;slug=<?= urlencode($childPage['slug']) ?>" class="<?= ($currentRoute === 'page' && ($activePageSlug ?? '') === $childPage['slug']) ? $mobileSubActive : $mobileSubBase ?>"><?= htmlspecialchars($childPage['title']) ?></a>
+                            <?php endforeach; ?>
+                        </div>
+                    <?php endif; ?>
+                </details>
+            <?php endforeach; ?>
+            <a href="<?= BASE_URL ?>/index.php?route=adoption" class="<?= ($currentRoute === 'adoption') ? $mobileLinkActive : $mobileLinkBase ?>">Tierabgabe</a>
+            <?php if (current_user()): ?>
+                <a href="<?= BASE_URL ?>/index.php?route=my-animals" class="<?= ($currentRoute === 'my-animals') ? $mobileLinkActive : $mobileLinkBase ?>">Meine Tiere</a>
+                <a href="<?= BASE_URL ?>/index.php?route=breeding" class="<?= ($currentRoute === 'breeding') ? $mobileLinkActive : $mobileLinkBase ?>">Zuchtplanung</a>
+                <a href="<?= BASE_URL ?>/index.php?route=admin/dashboard" class="<?= str_starts_with($currentRoute, 'admin/') ? $mobileLinkActive : $mobileLinkBase ?>">Admin</a>
+                <a href="<?= BASE_URL ?>/index.php?route=logout" class="<?= $mobileLinkBase ?>">Logout</a>
+            <?php else: ?>
+                <a href="<?= BASE_URL ?>/index.php?route=login" class="<?= ($currentRoute === 'login') ? $mobileLinkActive : $mobileLinkBase ?>">Login</a>
+            <?php endif; ?>
         </nav>
     </div>
 </header>
-<main>
-    <div class="wrapper">
+<main class="flex-1 pb-16 pt-12">

--- a/public/views/partials/header.php
+++ b/public/views/partials/header.php
@@ -1,88 +1,76 @@
 <!DOCTYPE html>
-<html lang="de">
+<html lang="<?= htmlspecialchars($pageMeta['lang'] ?? 'de') ?>">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title><?= htmlspecialchars($settings['site_title'] ?? APP_NAME) ?></title>
-    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
-    <script>
-        tailwind.config = {
-            theme: {
-                extend: {
-                    colors: {
-                        night: {
-                            900: '#020617',
-                            800: '#0f172a',
-                            700: '#1e293b',
-                        },
-                        brand: {
-                            400: '#22d3ee',
-                            500: '#06b6d4',
-                            600: '#0891b2',
-                        },
-                    },
-                    boxShadow: {
-                        glow: '0 25px 65px rgba(15, 118, 110, 0.35)',
-                    },
-                    fontFamily: {
-                        sans: ['Inter', 'system-ui', 'ui-sans-serif', 'Segoe UI', 'sans-serif'],
-                    },
-                }
-            }
-        };
-    </script>
+    <title><?= htmlspecialchars($pageMeta['full_title'] ?? ($settings['site_title'] ?? SITE_NAME)) ?></title>
+    <link rel="canonical" href="<?= htmlspecialchars($pageMeta['canonical'] ?? canonical_url()) ?>">
+    <meta name="description" content="<?= htmlspecialchars($pageMeta['description'] ?? '') ?>">
+    <meta name="keywords" content="<?= htmlspecialchars(PRIMARY_TOPIC) ?>">
+    <meta name="theme-color" content="#050918">
+    <meta property="og:site_name" content="<?= htmlspecialchars(SITE_NAME) ?>">
+    <meta property="og:title" content="<?= htmlspecialchars($pageMeta['og_title'] ?? '') ?>">
+    <meta property="og:description" content="<?= htmlspecialchars($pageMeta['og_description'] ?? '') ?>">
+    <meta property="og:url" content="<?= htmlspecialchars($pageMeta['canonical'] ?? canonical_url()) ?>">
+    <meta property="og:type" content="<?= htmlspecialchars($pageMeta['og_type'] ?? 'website') ?>">
+    <meta property="og:image" content="<?= htmlspecialchars($pageMeta['og_image'] ?? ORG_LOGO_URL) ?>">
+    <meta property="og:image:alt" content="<?= htmlspecialchars($pageMeta['og_image_alt'] ?? SITE_NAME) ?>">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="<?= htmlspecialchars($pageMeta['og_title'] ?? '') ?>">
+    <meta name="twitter:description" content="<?= htmlspecialchars($pageMeta['og_description'] ?? '') ?>">
+    <meta name="twitter:image" content="<?= htmlspecialchars($pageMeta['og_image'] ?? ORG_LOGO_URL) ?>">
+    <link rel="alternate" hreflang="de" href="<?= htmlspecialchars($pageMeta['canonical'] ?? canonical_url()) ?>">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="<?= asset('style.css') ?>">
 </head>
-<body class="min-h-screen bg-gradient-to-br from-night-900 via-night-800 to-slate-900 font-sans text-slate-100">
-<header class="sticky top-0 z-50 border-b border-white/5 bg-night-900/80 backdrop-blur">
-    <div class="mx-auto flex w-full max-w-7xl items-center justify-between px-4 py-4 sm:px-6 lg:px-8">
-        <a href="<?= BASE_URL ?>/index.php" class="flex items-center gap-3">
-            <span class="flex h-10 w-10 items-center justify-center rounded-full bg-brand-500/20 text-lg font-semibold text-brand-400 ring-2 ring-brand-500/30">
+<body>
+<a class="skip-link" href="#main">Zum Inhalt springen</a>
+<header class="site-header">
+    <div class="site-header__bar">
+        <a href="<?= BASE_URL ?>/index.php" class="site-header__brand">
+            <span class="site-header__brand-logo">
                 <?= strtoupper(substr($settings['site_title'] ?? APP_NAME, 0, 2)) ?>
             </span>
-            <span>
-                <span class="block text-lg font-semibold tracking-wide text-slate-100"><?= htmlspecialchars($settings['site_title'] ?? APP_NAME) ?></span>
-                <span class="block text-sm text-slate-400"><?= htmlspecialchars($settings['site_tagline'] ?? '') ?></span>
+            <span class="site-header__brand-copy">
+                <strong><?= htmlspecialchars($settings['site_title'] ?? APP_NAME) ?></strong>
+                <span><?= htmlspecialchars($settings['site_tagline'] ?? 'FeroxZ Reptile Center') ?></span>
             </span>
         </a>
-        <div class="flex items-center gap-3 lg:hidden">
-            <button type="button" class="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-white/10 text-slate-200 shadow-sm shadow-brand-600/20 transition hover:border-brand-400 hover:text-brand-300" data-mobile-nav-toggle>
-                <span class="sr-only">Navigation umschalten</span>
-                <svg class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="1.6" viewBox="0 0 24 24" aria-hidden="true">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-                </svg>
-            </button>
-        </div>
+        <button type="button" class="site-header__toggle" data-nav-toggle aria-expanded="false" aria-controls="primary-navigation">
+            <span class="sr-only">Navigation öffnen</span>
+            <svg width="22" height="16" viewBox="0 0 22 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <path d="M1 1h20M1 8h20M1 15h20" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+            </svg>
+        </button>
         <?php
-            $navLinkBase = 'inline-flex items-center gap-1 rounded-full border border-white/10 px-4 py-2 text-slate-200 transition hover:border-brand-400 hover:bg-brand-500/10 hover:text-brand-100';
-            $navLinkActive = 'inline-flex items-center gap-1 rounded-full border border-brand-400 bg-brand-500/90 px-4 py-2 text-night-900 shadow-glow';
-            $dropdownLinkBase = 'block rounded-lg px-3 py-2 text-left text-slate-200 transition hover:bg-white/5 hover:text-brand-200';
-            $dropdownLinkActive = 'block rounded-lg px-3 py-2 text-left bg-brand-500/20 text-brand-100 shadow-inner shadow-brand-600/20';
-            $mobileLinkBase = 'block rounded-xl border border-white/5 px-4 py-2 text-slate-200 transition hover:border-brand-400 hover:bg-brand-500/10 hover:text-brand-100';
-            $mobileLinkActive = 'block rounded-xl border border-brand-400 bg-brand-500/20 px-4 py-2 text-brand-50 shadow-glow';
-            $mobileSubBase = 'block rounded-lg px-3 py-2 text-slate-300 hover:bg-brand-500/10 hover:text-brand-100';
-            $mobileSubActive = 'block rounded-lg px-3 py-2 text-brand-100 bg-brand-500/20';
+            $linkBase = 'site-nav__link';
+            $linkActive = 'site-nav__link site-nav__link--active';
         ?>
-        <nav class="hidden items-center gap-2 text-sm font-medium lg:flex" data-desktop-nav>
-            <a href="<?= BASE_URL ?>/index.php" class="<?= ($currentRoute === 'home') ? $navLinkActive : $navLinkBase ?>">Start</a>
-            <a href="<?= BASE_URL ?>/index.php?route=animals" class="<?= ($currentRoute === 'animals') ? $navLinkActive : $navLinkBase ?>">Tierübersicht</a>
-            <a href="<?= BASE_URL ?>/index.php?route=news" class="<?= ($currentRoute === 'news') ? $navLinkActive : $navLinkBase ?>">Neuigkeiten</a>
-            <div class="relative" data-nav-group>
-                <?php $isCareActive = ($currentRoute === 'care-guide' || $currentRoute === 'care-article'); ?>
-                <button type="button" class="<?= $isCareActive ? $navLinkActive : $navLinkBase ?>" data-nav-trigger>
+        <nav id="primary-navigation" class="site-nav" data-nav aria-label="Hauptnavigation">
+            <a href="<?= BASE_URL ?>/index.php" class="<?= ($currentRoute === 'home') ? $linkActive : $linkBase ?>">Start</a>
+            <?php $isCareActive = ($currentRoute === 'care-guide' || $currentRoute === 'care-article'); ?>
+            <div class="site-nav__group" data-nav-group>
+                <button type="button" class="<?= $isCareActive ? $linkActive : $linkBase ?>" data-nav-trigger aria-expanded="false">
                     Pflegeleitfaden
-                    <svg class="h-4 w-4 transition" data-chevron fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M6 9l6 6 6-6" />
+                    <svg width="16" height="10" viewBox="0 0 16 10" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                        <path d="M1 1l7 7 7-7" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
                     </svg>
                 </button>
-                <div class="nav-dropdown">
-                    <a href="<?= BASE_URL ?>/index.php?route=care-guide" class="<?= ($currentRoute === 'care-guide') ? $dropdownLinkActive : $dropdownLinkBase ?>">Übersicht</a>
+                <div class="site-nav__dropdown" role="menu">
+                    <a href="<?= BASE_URL ?>/index.php?route=care-guide" class="site-nav__dropdown-link" role="menuitem">Übersicht</a>
                     <?php foreach (($navCareArticles ?? []) as $careNav): ?>
-                        <a href="<?= BASE_URL ?>/index.php?route=care-article&amp;slug=<?= urlencode($careNav['slug']) ?>" class="<?= ($currentRoute === 'care-article' && ($activeCareSlug ?? '') === $careNav['slug']) ? $dropdownLinkActive : $dropdownLinkBase ?>"><?= htmlspecialchars($careNav['title']) ?></a>
+                        <a href="<?= BASE_URL ?>/index.php?route=care-article&amp;slug=<?= urlencode($careNav['slug']) ?>" class="site-nav__dropdown-link" role="menuitem">
+                            <?= htmlspecialchars($careNav['title']) ?>
+                        </a>
                     <?php endforeach; ?>
                 </div>
             </div>
-            <a href="<?= BASE_URL ?>/index.php?route=genetics" class="<?= ($currentRoute === 'genetics') ? $navLinkActive : $navLinkBase ?>">Genetik Rechner</a>
+            <a href="<?= BASE_URL ?>/index.php?route=genetics" class="<?= ($currentRoute === 'genetics') ? $linkActive : $linkBase ?>">Genetik-Rechner</a>
+            <a href="<?= BASE_URL ?>/index.php?route=animals" class="<?= ($currentRoute === 'animals') ? $linkActive : $linkBase ?>">Tierübersicht</a>
+            <a href="<?= BASE_URL ?>/index.php?route=adoption" class="<?= ($currentRoute === 'adoption') ? $linkActive : $linkBase ?>">Tierabgabe</a>
+            <a href="<?= BASE_URL ?>/index.php?route=news" class="<?= ($currentRoute === 'news') ? $linkActive : $linkBase ?>">Neuigkeiten</a>
             <?php foreach (($navPages ?? []) as $navPage): ?>
                 <?php
                     $parentActive = ($currentRoute === 'page' && ($activePageSlug ?? '') === $navPage['slug']);
@@ -95,90 +83,38 @@
                     }
                     $isActive = $parentActive || $childActive;
                 ?>
-                <div class="relative" data-nav-group>
-                    <a href="<?= BASE_URL ?>/index.php?route=page&amp;slug=<?= urlencode($navPage['slug']) ?>" class="<?= $isActive ? $navLinkActive : $navLinkBase ?>">
+                <div class="site-nav__group" data-nav-group>
+                    <button type="button" class="<?= $isActive ? $linkActive : $linkBase ?>" data-nav-trigger aria-expanded="false">
                         <?= htmlspecialchars($navPage['title']) ?>
                         <?php if (!empty($navPage['children'])): ?>
-                            <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M6 9l6 6 6-6" />
+                            <svg width="16" height="10" viewBox="0 0 16 10" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                                <path d="M1 1l7 7 7-7" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
                             </svg>
                         <?php endif; ?>
-                    </a>
-                    <?php if (!empty($navPage['children'])): ?>
-                        <div class="nav-dropdown">
-                            <?php foreach ($navPage['children'] as $childPage): ?>
-                                <a href="<?= BASE_URL ?>/index.php?route=page&amp;slug=<?= urlencode($childPage['slug']) ?>" class="<?= ($currentRoute === 'page' && ($activePageSlug ?? '') === $childPage['slug']) ? $dropdownLinkActive : $dropdownLinkBase ?>"><?= htmlspecialchars($childPage['title']) ?></a>
-                            <?php endforeach; ?>
-                        </div>
-                    <?php endif; ?>
+                    </button>
+                    <div class="site-nav__dropdown" role="menu">
+                        <a href="<?= BASE_URL ?>/index.php?route=page&amp;slug=<?= urlencode($navPage['slug']) ?>" class="site-nav__dropdown-link" role="menuitem">
+                            <?= htmlspecialchars($navPage['title']) ?> Übersicht
+                        </a>
+                        <?php foreach ($navPage['children'] ?? [] as $childPage): ?>
+                            <a href="<?= BASE_URL ?>/index.php?route=page&amp;slug=<?= urlencode($childPage['slug']) ?>" class="site-nav__dropdown-link" role="menuitem">
+                                <?= htmlspecialchars($childPage['title']) ?>
+                            </a>
+                        <?php endforeach; ?>
+                    </div>
                 </div>
             <?php endforeach; ?>
-            <a href="<?= BASE_URL ?>/index.php?route=adoption" class="<?= ($currentRoute === 'adoption') ? $navLinkActive : $navLinkBase ?>">Tierabgabe</a>
+            <a href="<?= BASE_URL ?>/index.php?route=page&amp;slug=ueber-uns" class="<?= ($currentRoute === 'page' && ($activePageSlug ?? '') === 'ueber-uns') ? $linkActive : $linkBase ?>">Über uns</a>
+            <a href="<?= BASE_URL ?>/index.php?route=page&amp;slug=kontakt" class="<?= ($currentRoute === 'page' && ($activePageSlug ?? '') === 'kontakt') ? $linkActive : $linkBase ?>">Kontakt</a>
             <?php if (current_user()): ?>
-                <a href="<?= BASE_URL ?>/index.php?route=my-animals" class="<?= ($currentRoute === 'my-animals') ? $navLinkActive : $navLinkBase ?>">Meine Tiere</a>
-                <a href="<?= BASE_URL ?>/index.php?route=breeding" class="<?= ($currentRoute === 'breeding') ? $navLinkActive : $navLinkBase ?>">Zuchtplanung</a>
-                <a href="<?= BASE_URL ?>/index.php?route=admin/dashboard" class="<?= str_starts_with($currentRoute, 'admin/') ? $navLinkActive : $navLinkBase ?>">Admin</a>
-                <a href="<?= BASE_URL ?>/index.php?route=logout" class="<?= $navLinkBase ?>">Logout</a>
+                <a href="<?= BASE_URL ?>/index.php?route=my-animals" class="<?= ($currentRoute === 'my-animals') ? $linkActive : $linkBase ?>">Meine Tiere</a>
+                <a href="<?= BASE_URL ?>/index.php?route=breeding" class="<?= ($currentRoute === 'breeding') ? $linkActive : $linkBase ?>">Zuchtplanung</a>
+                <a href="<?= BASE_URL ?>/index.php?route=admin/dashboard" class="<?= str_starts_with($currentRoute, 'admin/') ? $linkActive : $linkBase ?>">Admin</a>
+                <a href="<?= BASE_URL ?>/index.php?route=logout" class="<?= $linkBase ?>">Logout</a>
             <?php else: ?>
-                <a href="<?= BASE_URL ?>/index.php?route=login" class="<?= ($currentRoute === 'login') ? $navLinkActive : $navLinkBase ?>">Login</a>
-            <?php endif; ?>
-        </nav>
-    </div>
-    <div class="hidden lg:hidden" data-mobile-nav-panel>
-        <nav class="mx-4 mb-4 space-y-2 rounded-2xl border border-white/5 bg-night-900/95 p-4 text-sm shadow-lg shadow-brand-600/10">
-            <a href="<?= BASE_URL ?>/index.php" class="<?= ($currentRoute === 'home') ? $mobileLinkActive : $mobileLinkBase ?>">Start</a>
-            <a href="<?= BASE_URL ?>/index.php?route=animals" class="<?= ($currentRoute === 'animals') ? $mobileLinkActive : $mobileLinkBase ?>">Tierübersicht</a>
-            <a href="<?= BASE_URL ?>/index.php?route=news" class="<?= ($currentRoute === 'news') ? $mobileLinkActive : $mobileLinkBase ?>">Neuigkeiten</a>
-            <details class="group" <?= $isCareActive ? 'open' : '' ?>>
-                <summary class="<?= $mobileLinkBase ?> flex cursor-pointer list-none items-center justify-between">
-                    <span>Pflegeleitfaden</span>
-                    <svg class="h-4 w-4 transition group-open:rotate-180" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M6 9l6 6 6-6" /></svg>
-                </summary>
-                <div class="mt-2 space-y-1 pl-3 text-sm">
-                    <a href="<?= BASE_URL ?>/index.php?route=care-guide" class="<?= ($currentRoute === 'care-guide') ? $mobileSubActive : $mobileSubBase ?>">Übersicht</a>
-                    <?php foreach (($navCareArticles ?? []) as $careNav): ?>
-                        <a href="<?= BASE_URL ?>/index.php?route=care-article&amp;slug=<?= urlencode($careNav['slug']) ?>" class="<?= ($currentRoute === 'care-article' && ($activeCareSlug ?? '') === $careNav['slug']) ? $mobileSubActive : $mobileSubBase ?>"><?= htmlspecialchars($careNav['title']) ?></a>
-                    <?php endforeach; ?>
-                </div>
-            </details>
-            <a href="<?= BASE_URL ?>/index.php?route=genetics" class="<?= ($currentRoute === 'genetics') ? $mobileLinkActive : $mobileLinkBase ?>">Genetik Rechner</a>
-            <?php foreach (($navPages ?? []) as $navPage): ?>
-                <?php
-                    $parentActive = ($currentRoute === 'page' && ($activePageSlug ?? '') === $navPage['slug']);
-                    $childActive = false;
-                    foreach ($navPage['children'] ?? [] as $childPage) {
-                        if ($currentRoute === 'page' && ($activePageSlug ?? '') === $childPage['slug']) {
-                            $childActive = true;
-                            break;
-                        }
-                    }
-                ?>
-                <details class="group" <?= ($parentActive || $childActive) ? 'open' : '' ?>>
-                    <summary class="<?= $mobileLinkBase ?> flex cursor-pointer list-none items-center justify-between">
-                        <span><?= htmlspecialchars($navPage['title']) ?></span>
-                        <?php if (!empty($navPage['children'])): ?>
-                            <svg class="h-4 w-4 transition group-open:rotate-180" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M6 9l6 6 6-6" /></svg>
-                        <?php endif; ?>
-                    </summary>
-                    <?php if (!empty($navPage['children'])): ?>
-                        <div class="mt-2 space-y-1 pl-3 text-sm">
-                            <?php foreach ($navPage['children'] as $childPage): ?>
-                                <a href="<?= BASE_URL ?>/index.php?route=page&amp;slug=<?= urlencode($childPage['slug']) ?>" class="<?= ($currentRoute === 'page' && ($activePageSlug ?? '') === $childPage['slug']) ? $mobileSubActive : $mobileSubBase ?>"><?= htmlspecialchars($childPage['title']) ?></a>
-                            <?php endforeach; ?>
-                        </div>
-                    <?php endif; ?>
-                </details>
-            <?php endforeach; ?>
-            <a href="<?= BASE_URL ?>/index.php?route=adoption" class="<?= ($currentRoute === 'adoption') ? $mobileLinkActive : $mobileLinkBase ?>">Tierabgabe</a>
-            <?php if (current_user()): ?>
-                <a href="<?= BASE_URL ?>/index.php?route=my-animals" class="<?= ($currentRoute === 'my-animals') ? $mobileLinkActive : $mobileLinkBase ?>">Meine Tiere</a>
-                <a href="<?= BASE_URL ?>/index.php?route=breeding" class="<?= ($currentRoute === 'breeding') ? $mobileLinkActive : $mobileLinkBase ?>">Zuchtplanung</a>
-                <a href="<?= BASE_URL ?>/index.php?route=admin/dashboard" class="<?= str_starts_with($currentRoute, 'admin/') ? $mobileLinkActive : $mobileLinkBase ?>">Admin</a>
-                <a href="<?= BASE_URL ?>/index.php?route=logout" class="<?= $mobileLinkBase ?>">Logout</a>
-            <?php else: ?>
-                <a href="<?= BASE_URL ?>/index.php?route=login" class="<?= ($currentRoute === 'login') ? $mobileLinkActive : $mobileLinkBase ?>">Login</a>
+                <a href="<?= BASE_URL ?>/index.php?route=login" class="<?= ($currentRoute === 'login') ? $linkActive : $linkBase ?>">Login</a>
             <?php endif; ?>
         </nav>
     </div>
 </header>
-<main class="flex-1 pb-16 pt-12">
+<main id="main">

--- a/scripts/generate-responsive-images.php
+++ b/scripts/generate-responsive-images.php
@@ -1,0 +1,98 @@
+<?php
+require_once __DIR__ . '/../app/site.php';
+require_once __DIR__ . '/../app/helpers.php';
+
+$sourceDir = realpath(__DIR__ . '/../uploads');
+if ($sourceDir === false) {
+    fwrite(STDERR, "Upload-Verzeichnis nicht gefunden.\n");
+    exit(1);
+}
+
+$breakpoints = [480, 768, 1024, 1600];
+$formats = ['webp', 'avif'];
+
+function ensurePath(string $path): void
+{
+    if (!is_dir($path)) {
+        mkdir($path, 0775, true);
+    }
+}
+
+function convertImage(string $source, string $destination, int $width, string $format): void
+{
+    if (class_exists('Imagick')) {
+        $image = new Imagick($source);
+        $image->setImageFormat($format);
+        $image->setImageCompressionQuality(82);
+        $image->resizeImage($width, 0, Imagick::FILTER_LANCZOS, 1, true);
+        $image->writeImage($destination);
+        $image->destroy();
+        return;
+    }
+
+    $info = getimagesize($source);
+    if (!$info) {
+        throw new RuntimeException('Bildinformationen konnten nicht gelesen werden: ' . $source);
+    }
+
+    $createFunc = match ($info[2]) {
+        IMAGETYPE_JPEG => 'imagecreatefromjpeg',
+        IMAGETYPE_PNG => 'imagecreatefrompng',
+        IMAGETYPE_GIF => 'imagecreatefromgif',
+        default => null,
+    };
+
+    if (!$createFunc || !function_exists($createFunc)) {
+        copy($source, $destination);
+        return;
+    }
+
+    $image = $createFunc($source);
+    $height = (int)floor(imagesy($image) * ($width / imagesx($image)));
+    $canvas = imagescale($image, $width, $height, IMG_BICUBIC_FIXED);
+
+    if ($format === 'webp' && function_exists('imagewebp')) {
+        imagewebp($canvas, $destination, 82);
+    } elseif ($format === 'avif' && function_exists('imageavif')) {
+        imageavif($canvas, $destination, 45);
+    } else {
+        imagejpeg($canvas, $destination, 82);
+    }
+
+    imagedestroy($canvas);
+    imagedestroy($image);
+}
+
+$iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($sourceDir));
+foreach ($iterator as $file) {
+    if (!$file->isFile()) {
+        continue;
+    }
+    $ext = strtolower($file->getExtension());
+    if (!in_array($ext, ['jpg', 'jpeg', 'png', 'gif'], true)) {
+        continue;
+    }
+
+    $relativePath = trim(str_replace($sourceDir, '', $file->getPathname()), DIRECTORY_SEPARATOR);
+    $baseName = pathinfo($relativePath, PATHINFO_FILENAME);
+    $subDir = 'media/generated/' . dirname($relativePath);
+    $subDir = rtrim($subDir, './');
+    if ($subDir === 'media/generated') {
+        $targetPath = __DIR__ . '/../public/' . $subDir;
+    } else {
+        $targetPath = __DIR__ . '/../public/' . $subDir;
+    }
+    ensurePath($targetPath);
+
+    foreach ($breakpoints as $width) {
+        foreach ($formats as $format) {
+            $outputFile = $targetPath . '/' . $baseName . '_' . $width . '.' . $format;
+            try {
+                convertImage($file->getPathname(), $outputFile, $width, $format);
+                echo "Erzeugt: {$outputFile}\n";
+            } catch (Throwable $e) {
+                fwrite(STDERR, 'Fehler bei ' . $outputFile . ': ' . $e->getMessage() . "\n");
+            }
+        }
+    }
+}

--- a/scripts/lhci.config.js
+++ b/scripts/lhci.config.js
@@ -1,0 +1,24 @@
+module.exports = {
+  ci: {
+    collect: {
+      numberOfRuns: 1,
+      url: [
+        'http://localhost:8080/',
+        'http://localhost:8080/index.php?route=adoption',
+        'http://localhost:8080/index.php?route=care-guide'
+      ],
+    },
+    upload: {
+      target: 'filesystem',
+      outputDir: 'reports/lighthouse'
+    },
+    assert: {
+      assertions: {
+        'categories:performance': ['error', {minScore: 0.9}],
+        'categories:accessibility': ['error', {minScore: 0.95}],
+        'categories:seo': ['error', {minScore: 0.95}],
+        'categories:best-practices': ['error', {minScore: 0.95}]
+      }
+    }
+  }
+};

--- a/scripts/purge-cache.sh
+++ b/scripts/purge-cache.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${CLOUDFLARE_ZONE_ID:-}" || -z "${CLOUDFLARE_API_TOKEN:-}" ]]; then
+  echo "Skipping CDN purge: CLOUDFLARE_ZONE_ID or CLOUDFLARE_API_TOKEN not set" >&2
+  exit 0
+fi
+
+curl -X POST "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
+  -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data '{"purge_everything":true}'

--- a/scripts/schema-check.mjs
+++ b/scripts/schema-check.mjs
@@ -1,0 +1,23 @@
+import { promises as fs } from 'fs';
+import fetch from 'node-fetch';
+
+const baseUrl = process.env.SCHEMA_BASE_URL || 'http://localhost:8080';
+const paths = ['/', '/index.php?route=adoption', '/index.php?route=care-guide', '/index.php?route=news'];
+const report = [];
+
+for (const path of paths) {
+  const url = `${baseUrl}${path}`;
+  try {
+    const response = await fetch(url);
+    const html = await response.text();
+    const matches = [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)];
+    const parsed = matches.map(([, json]) => JSON.parse(json));
+    report.push({ url, schemaCount: parsed.length, ok: true });
+  } catch (error) {
+    report.push({ url, ok: false, error: error.message });
+  }
+}
+
+await fs.mkdir('reports', { recursive: true });
+await fs.writeFile('reports/schema-validation.json', JSON.stringify(report, null, 2));
+console.log('Schema validation report written to reports/schema-validation.json');

--- a/Änderungsübersicht.md
+++ b/Änderungsübersicht.md
@@ -1,0 +1,37 @@
+# Änderungen
+
+## Performance
+- Responsive Picture-Komponente (`render_responsive_picture`) für WebP/AVIF + Lazy-Loading.
+- Build-Skript `scripts/generate-responsive-images.php` und `npm run build:images`.
+- HTTP-Caching-Regeln via `public/.htaccess` inklusive CDN-Rewrite und Sicherheitsheadern.
+
+## SEO
+- Dynamische Meta-/OpenGraph-Tags und Canonicals mit Breadcrumb-Ausgabe pro Seite.
+- Strukturierte Daten (Organization, BreadcrumbList, Article, Product, SoftwareApplication) gebündelt im Footer.
+- Sitemap-Generator (`public/sitemap.php`) und robots.txt mit automatischer Rewrite-Regel.
+
+## Accessibility
+- Skip-Link, verbesserte Fokusdarstellung und `aria`-optimierte Navigation.
+- Inhaltsverzeichnis + Lesedauer in Pflegeartikeln.
+- Geschlechtsauswahl in allen Tierformularen mit tastaturbedienbaren Icon-Optionen.
+
+## UX & IA
+- Vollflächiges Aurora-Layout mit neuem Header, Glas-Navigation und 100%-Viewport-Sektionen auf allen Geräten.
+- Startseiten-Hero mit drei zentralen CTAs, Kennzahlen und Vertrauenssektion.
+- Vereinheitlichte Tier-, Vermittlungs- und Guide-Ansichten mit responsiven Bildern, Rich-Text-Blöcken und Barrierefreiheit.
+- Adminbereich mit optimierter Shell für Desktop und Mobile inklusive breiter Tabellen und Formular-Gitter.
+
+## Infrastruktur & QA
+- Health-Endpoint (`/index.php?route=healthz`) für Monitoring.
+- QA-Tooling über `npm run audit` (Lighthouse CI, HTML-Validator, Schema-Check) mit Reports-Verzeichnis.
+- CDN-Purge-Skript `scripts/purge-cache.sh` und Dokumentation in `README_DEPLOY.md`.
+
+## Neue Routen/Endpunkte
+- `/index.php?route=healthz`
+- `/sitemap.xml` (Rewrite auf `sitemap.php`)
+- `/robots.txt`
+
+## Konfigurationsschalter
+- `ASSET_CDN_URL`
+- `FEATURE_GENETICS_TEASER`
+- `CLOUDFLARE_ZONE_ID` / `CLOUDFLARE_API_TOKEN`


### PR DESCRIPTION
## Summary
- add probability fraction helpers and refactor the genetics view so parents are chosen via searchable multi-select chips with MorphMarket-inspired layout
- refresh the genetics results table to show probability fractions, trait pills, and morph labels while preserving the per-species gene reference
- update the calculator JavaScript and styling to support inline suggestions, keyboard controls, and global clearing actions for both parents

## Testing
- `find public app -name "*.php" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68dc188ffde8832b9cbdc63522c240f3